### PR TITLE
修复iOS8以下相册选择按钮不出现问题&解决取图内存瞬间占用过高问题

### DIFF
--- a/TZImagePickerController/TZImagePickerController/TZAssetCell.m
+++ b/TZImagePickerController/TZImagePickerController/TZAssetCell.m
@@ -35,6 +35,7 @@
 
 - (void)setModel:(TZAssetModel *)model {
     _model = model;
+    [self selectPhotoButton];
     if (iOS8Later) {
         self.representedAssetIdentifier = [[TZImageManager manager] getAssetIdentifier:model.asset];
     }

--- a/TZImagePickerController/TZImagePickerController/TZImageManager.m
+++ b/TZImagePickerController/TZImagePickerController/TZImageManager.m
@@ -333,7 +333,9 @@ static CGFloat TZScreenScale;
             CGFloat pixelHeight = photoWidth / aspectRatio;
             imageSize = CGSizeMake(pixelWidth, pixelHeight);
         }
-       PHImageRequestID imageRequestID = [[PHImageManager defaultManager] requestImageForAsset:asset targetSize:imageSize contentMode:PHImageContentModeAspectFill options:nil resultHandler:^(UIImage * _Nullable result, NSDictionary * _Nullable info) {
+        PHImageRequestOptions *option = [[PHImageRequestOptions alloc] init];
+        option.resizeMode = PHImageRequestOptionsResizeModeFast; //解决取图内存瞬间占用过高问题
+        PHImageRequestID imageRequestID = [[PHImageManager defaultManager] requestImageForAsset:asset targetSize:imageSize contentMode:PHImageContentModeAspectFill options:option resultHandler:^(UIImage * _Nullable result, NSDictionary * _Nullable info) {
             BOOL downloadFinined = (![[info objectForKey:PHImageCancelledKey] boolValue] && ![info objectForKey:PHImageErrorKey]);
             if (downloadFinined && result) {
                 result = [self fixOrientation:result];


### PR DESCRIPTION
1.iOS8以下相册按selectPhotoButton不出现问题
2.解决取图内存瞬间占用过高问题