### PR TITLE
权限修补

### DIFF
--- a/TZImagePickerController/TZImagePickerController/TZImageManager.m
+++ b/TZImagePickerController/TZImagePickerController/TZImageManager.m
@@ -27,8 +27,11 @@ static CGFloat TZScreenScale;
     dispatch_once(&onceToken, ^{
         manager = [[self alloc] init];
         manager.cachingImageManager = [[PHCachingImageManager alloc] init];
-        manager.cachingImageManager.allowsCachingHighQualityImages = NO;
-        
+        if (iOS8Later) {
+            if ([PHPhotoLibrary authorizationStatus] == ALAuthorizationStatusNotDetermined) {
+                manager.cachingImageManager.allowsCachingHighQualityImages = NO;
+            }
+        }        
         TZScreenWidth = [UIScreen mainScreen].bounds.size.width;
         // 测试发现，如果scale在plus真机上取到3.0，内存会增大特别多。故这里写死成2.0
         TZScreenScale = 2.0;

--- a/TZImagePickerController/TZImagePickerController/TZImageManager.m
+++ b/TZImagePickerController/TZImagePickerController/TZImageManager.m
@@ -27,11 +27,6 @@ static CGFloat TZScreenScale;
     dispatch_once(&onceToken, ^{
         manager = [[self alloc] init];
         manager.cachingImageManager = [[PHCachingImageManager alloc] init];
-        if (iOS8Later) {
-            if ([PHPhotoLibrary authorizationStatus] == ALAuthorizationStatusNotDetermined) {
-                manager.cachingImageManager.allowsCachingHighQualityImages = NO;
-            }
-        }        
         TZScreenWidth = [UIScreen mainScreen].bounds.size.width;
         // 测试发现，如果scale在plus真机上取到3.0，内存会增大特别多。故这里写死成2.0
         TZScreenScale = 2.0;

--- a/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
+++ b/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
@@ -105,6 +105,9 @@
             
             _timer = [NSTimer scheduledTimerWithTimeInterval:0.2 target:self selector:@selector(observeAuthrizationStatusChange) userInfo:nil repeats:YES];
         } else {
+            if (iOS8Later) {
+                [TZImageManager manager].cachingImageManager.allowsCachingHighQualityImages = NO;
+            }
             [self pushToPhotoPickerVc];
         }
     }

--- a/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
+++ b/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
@@ -142,6 +142,9 @@
         [_tipLable removeFromSuperview];
         [_timer invalidate];
         _timer = nil;
+        if (iOS8Later) {
+            [TZImageManager manager].cachingImageManager.allowsCachingHighQualityImages = NO;
+        }
     }
 }
 


### PR DESCRIPTION
在iOS8.1上，如果用户在同意照片权限之后，再关闭权限，
manager.cachingImageManager.allowsCachingHighQualityImages = NO;
将会 crash。
对此进行修补