### PR TITLE
fix bug：修复iOS8下取消相册授权情况下访问相册闪退问题

### DIFF
--- a/TZImagePickerController/TZImagePickerController/TZImageManager.m
+++ b/TZImagePickerController/TZImagePickerController/TZImageManager.m
@@ -27,7 +27,15 @@ static CGFloat TZScreenScale;
     dispatch_once(&onceToken, ^{
         manager = [[self alloc] init];
         manager.cachingImageManager = [[PHCachingImageManager alloc] init];
-        manager.cachingImageManager.allowsCachingHighQualityImages = NO;
+        
+        if ([UIDevice currentDevice].systemVersion.floatValue >= 8.0 && [UIDevice currentDevice].systemVersion.floatValue < 9.0) {
+            //iOS8需要授权成功才能赋值allowsCachingHighQualityImages,否则会闪退
+            if ([PHPhotoLibrary authorizationStatus] == PHAuthorizationStatusAuthorized) {
+                manager.cachingImageManager.allowsCachingHighQualityImages = NO;
+            }
+        } else {
+            manager.cachingImageManager.allowsCachingHighQualityImages = NO;
+        }
         
         TZScreenWidth = [UIScreen mainScreen].bounds.size.width;
         // 测试发现，如果scale在plus真机上取到3.0，内存会增大特别多。故这里写死成2.0

--- a/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
+++ b/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
@@ -142,6 +142,13 @@
         [_tipLable removeFromSuperview];
         [_timer invalidate];
         _timer = nil;
+        
+        if ([UIDevice currentDevice].systemVersion.floatValue >= 8.0 && [UIDevice currentDevice].systemVersion.floatValue < 9.0) {
+            //iOS8需要授权成功才能赋值allowsCachingHighQualityImages,否则会闪退
+            if ([PHPhotoLibrary authorizationStatus] == PHAuthorizationStatusAuthorized) {
+                [TZImageManager manager].cachingImageManager.allowsCachingHighQualityImages = NO;
+            }
+        } 
     }
 }
 


### PR DESCRIPTION
TZImageManager 初始化单例时，在iOS8下未授权相册时，*
manager.cachingImageManager.allowsCachingHighQualityImages = NO *  执行时闪退
iOS8需要授权成功才能赋值allowsCachingHighQualityImages,否则会闪退，iOS9则不会