### PR TITLE
修复相册imageView重复创建

### DIFF
--- a/TZImagePickerController/TZImagePickerController/TZAssetCell.m
+++ b/TZImagePickerController/TZImagePickerController/TZAssetCell.m
@@ -213,7 +213,7 @@
 #pragma mark - Lazy load
 
 - (UIImageView *)posterImageView {
-    if (_arrowImageView == nil) {
+    if (_posterImageView == nil) {
         UIImageView *posterImageView = [[UIImageView alloc] init];
         posterImageView.contentMode = UIViewContentModeScaleAspectFill;
         posterImageView.clipsToBounds = YES;


### PR DESCRIPTION
多次从TZPhotoPickerController点击返回跳回TZImagePickerController时,点击Debug View Hierarchy,可以看到TZAlbumCell上的imageView会重复创建,并提示错误:<Error> : ImageIO: PNG No IDATs written into file, 查看TZAlbumCell后发现 posterImageView的懒加载出现问题