### PR TITLE
相册授权修改

### DIFF
--- a/TZImagePickerController/TZImagePickerController/TZImageManager.m
+++ b/TZImagePickerController/TZImagePickerController/TZImageManager.m
@@ -57,7 +57,15 @@ static CGFloat TZScreenScale;
 
 /// Return YES if Authorized 返回YES如果得到了授权
 - (BOOL)authorizationStatusAuthorized {
-    return [self authorizationStatus] == 3;
+    NSInteger status = [self authorizationStatus];
+    if (status == 0) {
+        /**
+         * 当某些情况下AuthorizationStatus == AuthorizationStatusNotDetermined时，无法弹出系统首次使用的授权alertView，系统应用设置里亦没有相册的设置，此时将无法使用，故作以下操作，弹出系统首次使用的授权alertView
+         */
+        [self requestAuthorizationWhenNotDetermined];
+    }
+    
+    return status == 3;
 }
 
 - (NSInteger)authorizationStatus {
@@ -67,6 +75,21 @@ static CGFloat TZScreenScale;
         return [ALAssetsLibrary authorizationStatus];
     }
     return NO;
+}
+
+//AuthorizationStatus == AuthorizationStatusNotDetermined 时询问授权弹出系统授权alertView
+- (void)requestAuthorizationWhenNotDetermined {
+    if (iOS8Later) {
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            [PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus status) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                });
+            }];
+        });
+    } else {
+        [self.assetLibrary enumerateGroupsWithTypes:ALAssetsGroupAll usingBlock:^(ALAssetsGroup *group, BOOL *stop) {
+        } failureBlock:nil];
+    }
 }
 
 #pragma mark - Get Album


### PR DESCRIPTION
当某些情况下AuthorizationStatus ==
AuthorizationStatusNotDetermined时，无法弹出系统首次使用的授权alertView，系统应用设置里亦没有相册的设置，此时将无法使用。对此种情况做了修改，使其弹出系统授权alertView。