### PR TITLE
BugFix:issues273

### DIFF
--- a/TZImagePickerController/TZImagePickerController/TZImageManager.h
+++ b/TZImagePickerController/TZImagePickerController/TZImageManager.h
@@ -39,7 +39,7 @@
 
 /// Return YES if Authorized 返回YES如果得到了授权
 - (BOOL)authorizationStatusAuthorized;
-- (NSInteger)authorizationStatus;
++ (NSInteger)authorizationStatus;
 
 /// Get Album 获得相册/相册数组
 - (void)getCameraRollAlbum:(BOOL)allowPickingVideo allowPickingImage:(BOOL)allowPickingImage completion:(void (^)(TZAlbumModel *model))completion;

--- a/TZImagePickerController/TZImagePickerController/TZImageManager.m
+++ b/TZImagePickerController/TZImagePickerController/TZImageManager.m
@@ -57,7 +57,7 @@ static CGFloat TZScreenScale;
 
 /// Return YES if Authorized 返回YES如果得到了授权
 - (BOOL)authorizationStatusAuthorized {
-    NSInteger status = [self authorizationStatus];
+    NSInteger status = [self.class authorizationStatus];
     if (status == 0) {
         /**
          * 当某些情况下AuthorizationStatus == AuthorizationStatusNotDetermined时，无法弹出系统首次使用的授权alertView，系统应用设置里亦没有相册的设置，此时将无法使用，故作以下操作，弹出系统首次使用的授权alertView
@@ -68,7 +68,7 @@ static CGFloat TZScreenScale;
     return status == 3;
 }
 
-- (NSInteger)authorizationStatus {
++ (NSInteger)authorizationStatus {
     if (iOS8Later) {
         return [PHPhotoLibrary authorizationStatus];
     } else {

--- a/TZImagePickerController/ViewController.m
+++ b/TZImagePickerController/ViewController.m
@@ -267,11 +267,11 @@
         UIAlertView * alert = [[UIAlertView alloc]initWithTitle:@"无法使用相机" message:@"请在iPhone的""设置-隐私-相机""中允许访问相机" delegate:self cancelButtonTitle:@"取消" otherButtonTitles:@"设置", nil];
         [alert show];
         // 拍照之前还需要检查相册权限
-    } else if ([[TZImageManager manager] authorizationStatus] == 2) { // 已被拒绝，没有相册权限，将无法保存拍的照片
+    } else if ([TZImageManager authorizationStatus] == 2) { // 已被拒绝，没有相册权限，将无法保存拍的照片
         UIAlertView * alert = [[UIAlertView alloc]initWithTitle:@"无法访问相册" message:@"请在iPhone的""设置-隐私-相册""中允许访问相册" delegate:self cancelButtonTitle:@"取消" otherButtonTitles:@"设置", nil];
         alert.tag = 1;
         [alert show];
-    } else if ([[TZImageManager manager] authorizationStatus] == 0) { // 正在弹框询问用户是否允许访问相册，监听权限状态
+    } else if ([TZImageManager authorizationStatus] == 0) { // 正在弹框询问用户是否允许访问相册，监听权限状态
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
             return [self takePhoto];
         });


### PR DESCRIPTION
TZImageManager构建单例时会[[PHCachingImageManager alloc]
init]初始化manager.cachingImageManager，此时如果未授权可能会出现上诉问题，具体原因不明，不排除是系统bug。根据听云和友盟数据反馈,只要未授权时不初始化manager.cachingImageManager，就不会出现。
所以将最开始就会调用的询问授权的方法改成+方法，即先不创建单例不初始化manager.cachingImageManager。