### PR TITLE
修复：当照片按时间降序排列时，选取照片错误问题。

### DIFF
--- a/TZImagePickerController/TZImagePickerController/TZPhotoPickerController.m
+++ b/TZImagePickerController/TZImagePickerController/TZPhotoPickerController.m
@@ -635,7 +635,11 @@ static CGSize AssetGridThumbnailSize;
             if (tzImagePickerVc.maxImagesCount <= 1) {
                 if (tzImagePickerVc.allowCrop) {
                     TZPhotoPreviewController *photoPreviewVc = [[TZPhotoPreviewController alloc] init];
-                    photoPreviewVc.currentIndex = _models.count - 1;
+                    if (tzImagePickerVc.sortAscendingByModificationDate) {
+                        photoPreviewVc.currentIndex = _models.count - 1;
+                    }else{
+                        photoPreviewVc.currentIndex = 0;
+                    }
                     photoPreviewVc.models = _models;
                     [self pushPhotoPrevireViewController:photoPreviewVc];
                 } else {


### PR DESCRIPTION
修复：当照片按时间降序排列时，选取照片错误问题。