### PR TITLE
修复问题：在 Preview 中滑动到 GIF 时，GIF 不能动，而且可以选中并回调一张静态图片

### DIFF
--- a/TZImagePickerController/TZImagePickerController/TZImageCropManager.m
+++ b/TZImagePickerController/TZImagePickerController/TZImageCropManager.m
@@ -115,6 +115,15 @@
 
 
 @implementation UIImage (TZGif)
++ (BOOL)isGIFImageData:(NSData *)data {
+    uint8_t c;
+    [data getBytes:&c length:1];
+    if (c == 0x47) {
+        return YES;
+    } else {
+        return NO;
+    }
+}
 
 + (UIImage *)sd_tz_animatedGIFWithData:(NSData *)data {
     if (!data) {

--- a/TZImagePickerController/TZImagePickerController/TZPhotoPreviewCell.h
+++ b/TZImagePickerController/TZImagePickerController/TZPhotoPreviewCell.h
@@ -39,5 +39,6 @@
 @property (nonatomic, copy) void (^singleTapGestureBlock)();
 @property (nonatomic, copy) void (^imageProgressUpdateBlock)(double progress);
 
+- (void)setGifAsset:(id)asset;
 - (void)recoverSubviews;
 @end

--- a/TZImagePickerController/TZImagePickerController/TZPhotoPreviewCell.m
+++ b/TZImagePickerController/TZImagePickerController/TZPhotoPreviewCell.m
@@ -41,7 +41,11 @@
 
 - (void)setModel:(TZAssetModel *)model {
     _model = model;
-    _previewView.asset = model.asset;
+        if (model.type != TZAssetModelMediaTypePhotoGif) {
+        _previewView.asset = model.asset;
+    } else {
+        [_previewView setGifAsset:model.asset];
+    }
 }
 
 - (void)recoverSubviews {
@@ -152,6 +156,16 @@
             self.imageProgressUpdateBlock(progress);
         }
     } networkAccessAllowed:YES];
+}
+
+- (void)setGifAsset:(id)asset {
+    _asset = asset;
+    [[TZImageManager manager] getOriginalPhotoDataWithAsset:asset completion:^(NSData *data, NSDictionary *info, BOOL isDegraded) {
+        if (!isDegraded) {
+            self.imageView.image = [UIImage sd_tz_animatedGIFWithData:data];
+            [self resizeSubviews];
+        }
+    }];
 }
 
 - (void)recoverSubviews {

--- a/TZImagePickerController/TZImagePickerController/TZPhotoPreviewController.m
+++ b/TZImagePickerController/TZImagePickerController/TZPhotoPreviewController.m
@@ -413,6 +413,13 @@
     
     _doneButton.hidden = NO;
     _selectButton.hidden = !_tzImagePickerVc.showSelectBtn;
+    // 让GIF不能被选中
+    if (model.type == TZAssetModelMediaTypePhotoGif) {
+        _selectButton.hidden = YES;
+        _originalPhotoLabel.hidden = YES;
+        _originalPhotoButton.hidden = YES;
+    }
+    
     // 让宽度/高度小于 最小可选照片尺寸 的图片不能选中
     if (![[TZImageManager manager] isPhotoSelectableWithAsset:model.asset]) {
         _numberLabel.hidden = YES;

--- a/TZImagePickerController/TZImagePickerController/TZPhotoPreviewController.m
+++ b/TZImagePickerController/TZImagePickerController/TZPhotoPreviewController.m
@@ -418,6 +418,7 @@
         _selectButton.hidden = YES;
         _originalPhotoLabel.hidden = YES;
         _originalPhotoButton.hidden = YES;
+        _doneButton.hidden = YES;
     }
     
     // 让宽度/高度小于 最小可选照片尺寸 的图片不能选中


### PR DESCRIPTION
改成 滑动到 GIF 可以动，但不能选择，交互上比微信原生的还好些。（微信是直接跳过 GIF 不显示）