### PR TITLE
兼容应用全局隐藏状态栏的情况

### DIFF
--- a/TZImagePickerController/Info.plist
+++ b/TZImagePickerController/Info.plist
@@ -36,6 +36,8 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>UIStatusBarHidden</key>
+	<true/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/TZImagePickerController/TZImagePickerController/TZGifPhotoPreviewController.m
+++ b/TZImagePickerController/TZImagePickerController/TZGifPhotoPreviewController.m
@@ -98,7 +98,10 @@
 - (void)signleTapAction {
     _toolBar.hidden = !_toolBar.isHidden;
     [self.navigationController setNavigationBarHidden:_toolBar.isHidden];
-    if (iOS7Later) [UIApplication sharedApplication].statusBarHidden = _toolBar.isHidden;
+    
+    if (!TZ_isGlobalHideStatusBar) {
+        if (iOS7Later) [UIApplication sharedApplication].statusBarHidden = _toolBar.isHidden;
+    }
 }
 
 - (void)doneButtonClick {

--- a/TZImagePickerController/TZImagePickerController/TZImagePickerController.h
+++ b/TZImagePickerController/TZImagePickerController/TZImagePickerController.h
@@ -25,6 +25,8 @@
 #define iOS9Later ([UIDevice currentDevice].systemVersion.floatValue >= 9.0f)
 #define iOS9_1Later ([UIDevice currentDevice].systemVersion.floatValue >= 9.1f)
 
+#define TZ_isGlobalHideStatusBar [[[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIStatusBarHidden"] boolValue]
+
 @protocol TZImagePickerControllerDelegate;
 @interface TZImagePickerController : UINavigationController
 

--- a/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
+++ b/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
@@ -45,6 +45,7 @@
     self.navigationBar.translucent = YES;
     [TZImageManager manager].shouldFixOrientation = NO;
     
+
     // Default appearance, you can reset these after this method
     // 默认的外观，你可以在这个方法后重置
     self.oKButtonTitleColorNormal   = [UIColor colorWithRed:(83/255.0) green:(179/255.0) blue:(17/255.0) alpha:1.0];

--- a/TZImagePickerController/TZImagePickerController/TZPhotoPreviewController.m
+++ b/TZImagePickerController/TZImagePickerController/TZPhotoPreviewController.m
@@ -65,7 +65,9 @@
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
     [self.navigationController setNavigationBarHidden:YES animated:YES];
-    if (iOS7Later) [UIApplication sharedApplication].statusBarHidden = YES;
+    if (!TZ_isGlobalHideStatusBar) {
+        if (iOS7Later) [UIApplication sharedApplication].statusBarHidden = YES;
+    }
     if (_currentIndex) [_collectionView setContentOffset:CGPointMake((self.view.tz_width + 20) * _currentIndex, 0) animated:NO];
     [self refreshNaviBarAndBottomBarState];
 }
@@ -73,7 +75,9 @@
 - (void)viewWillDisappear:(BOOL)animated {
     [super viewWillDisappear:animated];
     [self.navigationController setNavigationBarHidden:NO animated:YES];
-    if (iOS7Later) [UIApplication sharedApplication].statusBarHidden = NO;
+    if (!TZ_isGlobalHideStatusBar) {
+        if (iOS7Later) [UIApplication sharedApplication].statusBarHidden = NO;
+    }
     [TZImageManager manager].shouldFixOrientation = NO;
 }
 

--- a/TZImagePickerController/TZImagePickerController/TZVideoPlayerController.m
+++ b/TZImagePickerController/TZImagePickerController/TZVideoPlayerController.m
@@ -125,7 +125,9 @@
         [self.navigationController setNavigationBarHidden:YES];
         _toolBar.hidden = YES;
         [_playButton setImage:nil forState:UIControlStateNormal];
-        if (iOS7Later) [UIApplication sharedApplication].statusBarHidden = YES;
+        if (!TZ_isGlobalHideStatusBar) {
+            if (iOS7Later) [UIApplication sharedApplication].statusBarHidden = YES;
+        }
     } else {
         [self pausePlayerAndShowNaviBar];
     }
@@ -163,7 +165,10 @@
     _toolBar.hidden = NO;
     [self.navigationController setNavigationBarHidden:NO];
     [_playButton setImage:[UIImage imageNamedFromMyBundle:@"MMVideoPreviewPlay.png"] forState:UIControlStateNormal];
-    if (iOS7Later) [UIApplication sharedApplication].statusBarHidden = NO;
+    
+    if (!TZ_isGlobalHideStatusBar) {
+        if (iOS7Later) [UIApplication sharedApplication].statusBarHidden = NO;
+    }
 }
 
 - (void)dealloc {


### PR DESCRIPTION
当应用有全局隐藏状态栏的需求时，点击进入该库某些页面，退出页面后又会把状态栏给显示出来，这个 commit 简单做了点兼容。