### PR TITLE
解决当设置 autoDismiss = NO 的时候，点击视频预览页面的完成按钮后，回调没有被调用的问题

### DIFF
--- a/TZImagePickerController/TZImagePickerController/TZVideoPlayerController.m
+++ b/TZImagePickerController/TZImagePickerController/TZVideoPlayerController.m
@@ -140,6 +140,8 @@
             [self.navigationController dismissViewControllerAnimated:YES completion:^{
                 [self callDelegateMethod];
             }];
+        } else {
+            [self callDelegateMethod];
         }
     } else {
         [self dismissViewControllerAnimated:YES completion:^{


### PR DESCRIPTION
`- (void)doneButtonClick {
    TZImagePickerController *imagePickerVc = (TZImagePickerController *)self.navigationController;
    if (self.navigationController) {
        if (imagePickerVc.autoDismiss) {
            [self.navigationController dismissViewControllerAnimated:YES completion:^{
                [self callDelegateMethod];
            }];
        } 
        // 即使自动dismiss关了，也因该调用回调
    } else {
        [self dismissViewControllerAnimated:YES completion:^{
            [self callDelegateMethod];
        }];
    }
}`