### PR TITLE
解决当设置 autoDismiss = NO 的时候，点击 Gif 预览页面的完成按钮后，回调没有被调用的问题

### DIFF
--- a/TZImagePickerController/TZImagePickerController/TZGifPhotoPreviewController.m
+++ b/TZImagePickerController/TZImagePickerController/TZGifPhotoPreviewController.m
@@ -111,6 +111,8 @@
             [self.navigationController dismissViewControllerAnimated:YES completion:^{
                 [self callDelegateMethod];
             }];
+        } else {
+            [self callDelegateMethod];
         }
     } else {
         [self dismissViewControllerAnimated:YES completion:^{


### PR DESCRIPTION
解决当设置 autoDismiss = NO 的时候，点击 Gif 预览页面的完成按钮后，回调没有被调用的问题