### PR TITLE
resultHandler重复调用

### DIFF
--- a/TZImagePickerController/TZImagePickerController/TZImageManager.m
+++ b/TZImagePickerController/TZImagePickerController/TZImageManager.m
@@ -580,7 +580,7 @@ static dispatch_once_t onceToken;
         option.networkAccessAllowed = YES;
         option.resizeMode = PHImageRequestOptionsResizeModeFast;
         [[PHImageManager defaultManager] requestImageForAsset:asset targetSize:PHImageManagerMaximumSize contentMode:PHImageContentModeAspectFit options:option resultHandler:^(UIImage *result, NSDictionary *info) {
-            BOOL downloadFinined = (![[info objectForKey:PHImageCancelledKey] boolValue] && ![info objectForKey:PHImageErrorKey]);
+            BOOL downloadFinined = (![[info objectForKey:PHImageCancelledKey] boolValue] && ![info objectForKey:PHImageErrorKey] && ![[info objectForKey:PHImageResultIsDegradedKey] boolValue]);
             if (downloadFinined && result) {
                 result = [self fixOrientation:result];
                 BOOL isDegraded = [[info objectForKey:PHImageResultIsDegradedKey] boolValue];


### PR DESCRIPTION
图像需要从 iCloud 中下载时首先会返回低清晰度的图片，然后会返回高清版，需要高清图时需要过滤掉低清晰度的图