### PR TITLE
[GL][解决][Info.plist文件换了路径时，提示app名称显示(null)的问题]

### DIFF
--- a/TZImagePickerController/TZImagePickerController/TZImagePickerController.h
+++ b/TZImagePickerController/TZImagePickerController/TZImagePickerController.h
@@ -253,6 +253,8 @@
 @interface TZCommonTools : NSObject
 + (BOOL)tz_isIPhoneX;
 + (CGFloat)tz_statusBarHeight;
+// 获得Info.plist数据字典
++ (NSDictionary *)tz_getInfoDictionary;
 @end
 
 

--- a/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
+++ b/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
@@ -186,6 +186,11 @@
             if (!infoDict || !infoDict.count) {
                 infoDict = [NSBundle mainBundle].infoDictionary;
             }
+            if (!infoDict || !infoDict.count) {
+                NSString *path = [[NSBundle mainBundle] pathForResource:@"Info" ofType:@"plist"];
+                infoDict = [NSDictionary dictionaryWithContentsOfFile:path];
+            }
+            
             NSString *appName = [infoDict valueForKey:@"CFBundleDisplayName"];
             if (!appName) appName = [infoDict valueForKey:@"CFBundleName"];
             NSString *tipText = [NSString stringWithFormat:[NSBundle tz_localizedStringForKey:@"Allow %@ to access your album in \"Settings -> Privacy -> Photos\""],appName];

--- a/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
+++ b/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
@@ -787,18 +787,14 @@
 
 // 获得Info.plist数据字典
 + (NSDictionary *)tz_getInfoDictionary {
-    
     NSDictionary *infoDict = [NSBundle mainBundle].localizedInfoDictionary;
-    
     if (!infoDict || !infoDict.count) {
         infoDict = [NSBundle mainBundle].infoDictionary;
     }
-    
     if (!infoDict || !infoDict.count) {
         NSString *path = [[NSBundle mainBundle] pathForResource:@"Info" ofType:@"plist"];
         infoDict = [NSDictionary dictionaryWithContentsOfFile:path];
     }
-    
     return infoDict ? infoDict : @{};
 }
 @end

--- a/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
+++ b/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
@@ -182,15 +182,8 @@
             _tipLabel.numberOfLines = 0;
             _tipLabel.font = [UIFont systemFontOfSize:16];
             _tipLabel.textColor = [UIColor blackColor];
-            NSDictionary *infoDict = [NSBundle mainBundle].localizedInfoDictionary;
-            if (!infoDict || !infoDict.count) {
-                infoDict = [NSBundle mainBundle].infoDictionary;
-            }
-            if (!infoDict || !infoDict.count) {
-                NSString *path = [[NSBundle mainBundle] pathForResource:@"Info" ofType:@"plist"];
-                infoDict = [NSDictionary dictionaryWithContentsOfFile:path];
-            }
             
+            NSDictionary *infoDict = [TZCommonTools tz_getInfoDictionary];
             NSString *appName = [infoDict valueForKey:@"CFBundleDisplayName"];
             if (!appName) appName = [infoDict valueForKey:@"CFBundleName"];
             NSString *tipText = [NSString stringWithFormat:[NSBundle tz_localizedStringForKey:@"Allow %@ to access your album in \"Settings -> Privacy -> Photos\""],appName];
@@ -792,6 +785,22 @@
     return [self tz_isIPhoneX] ? 44 : 20;
 }
 
+// 获得Info.plist数据字典
++ (NSDictionary *)tz_getInfoDictionary {
+    
+    NSDictionary *infoDict = [NSBundle mainBundle].localizedInfoDictionary;
+    
+    if (!infoDict || !infoDict.count) {
+        infoDict = [NSBundle mainBundle].infoDictionary;
+    }
+    
+    if (!infoDict || !infoDict.count) {
+        NSString *path = [[NSBundle mainBundle] pathForResource:@"Info" ofType:@"plist"];
+        infoDict = [NSDictionary dictionaryWithContentsOfFile:path];
+    }
+    
+    return infoDict ? infoDict : @{};
+}
 @end
 
 

--- a/TZImagePickerController/TZImagePickerController/TZPhotoPickerController.m
+++ b/TZImagePickerController/TZImagePickerController/TZPhotoPickerController.m
@@ -550,14 +550,7 @@ static CGFloat itemMargin = 5;
     AVAuthorizationStatus authStatus = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
     if ((authStatus == AVAuthorizationStatusRestricted || authStatus ==AVAuthorizationStatusDenied) && iOS7Later) {
         
-        NSDictionary *infoDict = [NSBundle mainBundle].localizedInfoDictionary;
-        if (!infoDict || !infoDict.count) {
-            infoDict = [NSBundle mainBundle].infoDictionary;
-        }
-        if (!infoDict || !infoDict.count) {
-            NSString *path = [[NSBundle mainBundle] pathForResource:@"Info" ofType:@"plist"];
-            infoDict = [NSDictionary dictionaryWithContentsOfFile:path];
-        }
+        NSDictionary *infoDict = [TZCommonTools tz_getInfoDictionary];
         // 无权限 做一个友好的提示
         NSString *appName = [infoDict valueForKey:@"CFBundleDisplayName"];
         if (!appName) appName = [infoDict valueForKey:@"CFBundleName"];

--- a/TZImagePickerController/TZImagePickerController/TZPhotoPickerController.m
+++ b/TZImagePickerController/TZImagePickerController/TZPhotoPickerController.m
@@ -549,9 +549,19 @@ static CGFloat itemMargin = 5;
 - (void)takePhoto {
     AVAuthorizationStatus authStatus = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
     if ((authStatus == AVAuthorizationStatusRestricted || authStatus ==AVAuthorizationStatusDenied) && iOS7Later) {
+        
+        NSDictionary *infoDict = [NSBundle mainBundle].localizedInfoDictionary;
+        if (!infoDict || !infoDict.count) {
+            infoDict = [NSBundle mainBundle].infoDictionary;
+        }
+        if (!infoDict || !infoDict.count) {
+            NSString *path = [[NSBundle mainBundle] pathForResource:@"Info" ofType:@"plist"];
+            infoDict = [NSDictionary dictionaryWithContentsOfFile:path];
+        }
         // 无权限 做一个友好的提示
-        NSString *appName = [[NSBundle mainBundle].infoDictionary valueForKey:@"CFBundleDisplayName"];
-        if (!appName) appName = [[NSBundle mainBundle].infoDictionary valueForKey:@"CFBundleName"];
+        NSString *appName = [infoDict valueForKey:@"CFBundleDisplayName"];
+        if (!appName) appName = [infoDict valueForKey:@"CFBundleName"];
+        
         NSString *message = [NSString stringWithFormat:[NSBundle tz_localizedStringForKey:@"Please allow %@ to access your camera in \"Settings -> Privacy -> Camera\""],appName];
         if (iOS8Later) {
             UIAlertView *alert = [[UIAlertView alloc] initWithTitle:[NSBundle tz_localizedStringForKey:@"Can not use camera"] message:message delegate:self cancelButtonTitle:[NSBundle tz_localizedStringForKey:@"Cancel"] otherButtonTitles:[NSBundle tz_localizedStringForKey:@"Setting"], nil];


### PR DESCRIPTION
## [GL][解决][Info.plist文件换了路径时，提示app名称显示(null)的问题]
<br>

![img_0239](https://user-images.githubusercontent.com/12198944/35856372-c8e21782-0b70-11e8-9fff-dd0487a8681c.png)
