### PR TITLE
修改选择最大数量少一张图时候，再进去选择没有可选择icon

### DIFF
--- a/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
+++ b/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
@@ -399,7 +399,7 @@
 
 - (void)setMaxImagesCount:(NSInteger)maxImagesCount {
     _maxImagesCount = maxImagesCount;
-    if (maxImagesCount > 1) {
+    if (maxImagesCount > 0) {
         _showSelectBtn = YES;
         _allowCrop = NO;
     }
@@ -408,7 +408,7 @@
 - (void)setShowSelectBtn:(BOOL)showSelectBtn {
     _showSelectBtn = showSelectBtn;
     // 多选模式下，不允许让showSelectBtn为NO
-    if (!showSelectBtn && _maxImagesCount > 1) {
+    if (!showSelectBtn && _maxImagesCount > 0) {
         _showSelectBtn = YES;
     }
 }


### PR DESCRIPTION
Hi:
先发现一个状况，在我看来应该算是bug。
正常情况下每个可选择图片会出现可选择icon，但是如果已经选择了max-1张之后，再进去选择，则不会出现可选择icon。
看了下是因为这里的判断是 >1 
````
- (void)setMaxImagesCount:(NSInteger)maxImagesCount {
    _maxImagesCount = maxImagesCount;
    if (maxImagesCount > 1) {
        _showSelectBtn = YES;
        _allowCrop = NO;
    }
}

- (void)setShowSelectBtn:(BOOL)showSelectBtn {
    _showSelectBtn = showSelectBtn;
    // 多选模式下，不允许让showSelectBtn为NO
    if (!showSelectBtn && _maxImagesCount > 1) {
        _showSelectBtn = YES;
    }
}

````