### PR TITLE
增加一个微信对预览界面done按钮的细节处理

### DIFF
--- a/TZImagePickerController/TZImagePickerController/TZPhotoPickerController.m
+++ b/TZImagePickerController/TZImagePickerController/TZPhotoPickerController.m
@@ -343,6 +343,7 @@ static CGFloat itemMargin = 5;
 }
 - (void)previewButtonClick {
     TZPhotoPreviewController *photoPreviewVc = [[TZPhotoPreviewController alloc] init];
+    photoPreviewVc.enableDoneWhenNoneSelect = NO;
     [self pushPhotoPrevireViewController:photoPreviewVc needCheckSelectedModels:YES];
 }
 

--- a/TZImagePickerController/TZImagePickerController/TZPhotoPreviewController.h
+++ b/TZImagePickerController/TZImagePickerController/TZPhotoPreviewController.h
@@ -15,6 +15,7 @@
 @property (nonatomic, assign) NSInteger currentIndex;           ///< Index of the photo user click / 用户点击的图片的索引
 @property (nonatomic, assign) BOOL isSelectOriginalPhoto;       ///< If YES,return original photo / 是否返回原图
 @property (nonatomic, assign) BOOL isCropImage;
+@property (nonatomic, assign) BOOL enableDoneWhenNoneSelect;       ///< default is YES. If YES,return When no photos are selected, can you click the done button / 没有选择任何照片时，是否可以点击done按钮
 
 /// Return the new selected photos / 返回最新的选中图片数组
 @property (nonatomic, copy) void (^backButtonClickBlock)(BOOL isSelectOriginalPhoto);

--- a/TZImagePickerController/TZImagePickerController/TZPhotoPreviewController.m
+++ b/TZImagePickerController/TZImagePickerController/TZPhotoPreviewController.m
@@ -44,6 +44,15 @@
 
 @implementation TZPhotoPreviewController
 
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        _enableDoneWhenNoneSelect = YES;
+    }
+    return self;
+}
+
 - (void)viewDidLoad {
     [super viewDidLoad];
     [TZImageManager manager].shouldFixOrientation = YES;
@@ -336,6 +345,7 @@
     }
     model.isSelected = !selectButton.isSelected;
     [self refreshNaviBarAndBottomBarState];
+    [self checkDoneButtonEnable];
     if (model.isSelected) {
         [UIView showOscillatoryAnimationWithLayer:selectButton.imageView.layer type:TZOscillatoryAnimationToBigger];
     }
@@ -490,6 +500,19 @@
 
 - (void)dealloc {
     // NSLog(@"%@ dealloc",NSStringFromClass(self.class));
+}
+
+- (void)checkDoneButtonEnable {
+    if (!_enableDoneWhenNoneSelect) {
+        // When no photos are selected, can't click the done button
+        // 没有选择任何照片时，不可以点击done按钮
+        TZImagePickerController *_tzImagePickerVc = (TZImagePickerController *)self.navigationController;
+        if (_tzImagePickerVc.selectedModels.count == 0 && _tzImagePickerVc.minImagesCount <= 0) {
+            _doneButton.enabled = NO;
+        } else {
+            _doneButton.enabled = YES;
+        }
+    }
 }
 
 - (void)refreshNaviBarAndBottomBarState {


### PR DESCRIPTION
增加当从预览按钮进入预览界面时，如果取消选择所有图片，done按钮无法点击的交互方式。
ps:只设置了_doneButton.enabled = NO;不可点击下的字体颜色还没有设置。发现微信按钮的样式变成了主题绿色，文字白色的样式，在显示这种置灰的情况时UI效果更好。