### PR TITLE
解决Xcode9、Xcode10上大量警告

### DIFF
--- a/TZImagePickerController.xcodeproj/project.pbxproj
+++ b/TZImagePickerController.xcodeproj/project.pbxproj
@@ -444,25 +444,27 @@
 		900E65741C2BB8D5003D9A9E /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1000;
 				ORGANIZATIONNAME = "谭真";
 				TargetAttributes = {
 					900E657B1C2BB8D5003D9A9E = {
 						CreatedOnToolsVersion = 7.2;
-						DevelopmentTeam = T86X98NCU2;
+						DevelopmentTeam = QEQB6EZ8G4;
 						ProvisioningStyle = Automatic;
 					};
 					900E65941C2BB8D5003D9A9E = {
 						CreatedOnToolsVersion = 7.2;
+						DevelopmentTeam = QEQB6EZ8G4;
 						TestTargetID = 900E657B1C2BB8D5003D9A9E;
 					};
 					900E659F1C2BB8D5003D9A9E = {
 						CreatedOnToolsVersion = 7.2;
+						DevelopmentTeam = QEQB6EZ8G4;
 						TestTargetID = 900E657B1C2BB8D5003D9A9E;
 					};
 					9F763A411FA071CF00D9E526 = {
 						CreatedOnToolsVersion = 9.0.1;
-						DevelopmentTeam = T86X98NCU2;
+						DevelopmentTeam = QEQB6EZ8G4;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -750,7 +752,7 @@
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = T86X98NCU2;
+				DEVELOPMENT_TEAM = QEQB6EZ8G4;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/TZImagePickerController",
@@ -758,11 +760,11 @@
 				INFOPLIST_FILE = TZImagePickerController/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = tanzhen.TZImagePickerController.www;
+				PRODUCT_BUNDLE_IDENTIFIER = tanzhen.TZImagePickerController.zzg;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};
@@ -773,7 +775,7 @@
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = T86X98NCU2;
+				DEVELOPMENT_TEAM = QEQB6EZ8G4;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/TZImagePickerController",
@@ -781,11 +783,11 @@
 				INFOPLIST_FILE = TZImagePickerController/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = tanzhen.TZImagePickerController.www;
+				PRODUCT_BUNDLE_IDENTIFIER = tanzhen.TZImagePickerController.zzg;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};
@@ -793,6 +795,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEVELOPMENT_TEAM = QEQB6EZ8G4;
 				INFOPLIST_FILE = TZImagePickerControllerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = tanzhen.TZImagePickerControllerTests;
@@ -805,6 +808,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEVELOPMENT_TEAM = QEQB6EZ8G4;
 				INFOPLIST_FILE = TZImagePickerControllerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = tanzhen.TZImagePickerControllerTests;
@@ -816,6 +820,7 @@
 		900E65B01C2BB8D5003D9A9E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEVELOPMENT_TEAM = QEQB6EZ8G4;
 				INFOPLIST_FILE = TZImagePickerControllerUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = tanzhen.TZImagePickerControllerUITests;
@@ -828,6 +833,7 @@
 		900E65B11C2BB8D5003D9A9E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEVELOPMENT_TEAM = QEQB6EZ8G4;
 				INFOPLIST_FILE = TZImagePickerControllerUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = tanzhen.TZImagePickerControllerUITests;
@@ -858,7 +864,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = T86X98NCU2;
+				DEVELOPMENT_TEAM = QEQB6EZ8G4;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -898,7 +904,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = T86X98NCU2;
+				DEVELOPMENT_TEAM = QEQB6EZ8G4;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";

--- a/TZImagePickerController.xcodeproj/xcshareddata/xcschemes/TZImagePickerControllerFramework.xcscheme
+++ b/TZImagePickerController.xcodeproj/xcshareddata/xcschemes/TZImagePickerControllerFramework.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1000"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/TZImagePickerController/TZImagePickerController/TZAssetCell.m
+++ b/TZImagePickerController/TZImagePickerController/TZAssetCell.m
@@ -38,18 +38,23 @@
         self.model.cachedImage = nil;
         int32_t imageRequestID = [[TZImageManager manager] getPhotoWithAsset:model.asset photoWidth:self.tz_width completion:^(UIImage *photo, NSDictionary *info, BOOL isDegraded) {
             // Set the cell's thumbnail image if it's still showing the same asset.
-            if (!iOS8Later) {
+            if (iOS8Later) {
+                
+            } else {
                 self.imageView.image = photo;
                 self.model.cachedImage = photo;
                 [self hideProgressView];
                 return;
             }
+            
             if ([self.representedAssetIdentifier isEqualToString:[[TZImageManager manager] getAssetIdentifier:model.asset]]) {
                 self.imageView.image = photo;
                 self.model.cachedImage = photo;
             } else {
                 // NSLog(@"this cell is showing other asset");
-                [[PHImageManager defaultManager] cancelImageRequest:self.imageRequestID];
+                if (iOS8Later) {
+                    [[PHImageManager defaultManager] cancelImageRequest:self.imageRequestID];
+                }
             }
             if (!isDegraded) {
                 [self hideProgressView];
@@ -57,7 +62,9 @@
             }
         } progressHandler:nil networkAccessAllowed:NO];
         if (imageRequestID && self.imageRequestID && imageRequestID != self.imageRequestID) {
-            [[PHImageManager defaultManager] cancelImageRequest:self.imageRequestID];
+            if (iOS8Later) {
+                [[PHImageManager defaultManager] cancelImageRequest:self.imageRequestID];
+            }
             // NSLog(@"cancelImageRequest %d",self.imageRequestID);
         }
         self.imageRequestID = imageRequestID;
@@ -158,7 +165,9 @@
 
 - (void)requestBigImage {
     if (_bigImageRequestID) {
-        [[PHImageManager defaultManager] cancelImageRequest:_bigImageRequestID];
+        if (iOS8Later) {
+            [[PHImageManager defaultManager] cancelImageRequest:_bigImageRequestID];
+        }
     }
     
     _bigImageRequestID = [[TZImageManager manager] requestImageDataForAsset:_model.asset completion:^(NSData *imageData, NSString *dataUTI, UIImageOrientation orientation, NSDictionary *info) {
@@ -182,7 +191,9 @@
 
 - (void)cancelBigImageRequest {
     if (_bigImageRequestID) {
-        [[PHImageManager defaultManager] cancelImageRequest:_bigImageRequestID];
+        if (iOS8Later) {
+            [[PHImageManager defaultManager] cancelImageRequest:_bigImageRequestID];
+        }
     }
     [self hideProgressView];
 }

--- a/TZImagePickerController/TZImagePickerController/TZGifPhotoPreviewController.m
+++ b/TZImagePickerController/TZImagePickerController/TZGifPhotoPreviewController.m
@@ -43,7 +43,11 @@
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
     _originStatusBarStyle = [UIApplication sharedApplication].statusBarStyle;
-    [UIApplication sharedApplication].statusBarStyle = iOS7Later ? UIStatusBarStyleLightContent : UIStatusBarStyleBlackOpaque;
+    if (iOS7Later) {
+        [UIApplication sharedApplication].statusBarStyle = UIStatusBarStyleLightContent;
+    } else {
+        [UIApplication sharedApplication].statusBarStyle = UIStatusBarStyleBlackOpaque;
+    }
 }
 
 - (void)viewWillDisappear:(BOOL)animated {

--- a/TZImagePickerController/TZImagePickerController/TZImageManager.h
+++ b/TZImagePickerController/TZImagePickerController/TZImageManager.h
@@ -16,7 +16,11 @@
 @protocol TZImagePickerControllerDelegate;
 @interface TZImageManager : NSObject
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
+
 @property (nonatomic, strong) PHCachingImageManager *cachingImageManager;
+
+#endif
 
 + (instancetype)manager NS_SWIFT_NAME(default());
 + (void)deallocManager;

--- a/TZImagePickerController/TZImagePickerController/TZImagePickerController.h
+++ b/TZImagePickerController/TZImagePickerController/TZImagePickerController.h
@@ -25,11 +25,23 @@
 #import "TZLocationManager.h"
 #import "TZPhotoPreviewController.h"
 
-#define iOS7Later ([UIDevice currentDevice].systemVersion.floatValue >= 7.0f)
-#define iOS8Later ([UIDevice currentDevice].systemVersion.floatValue >= 8.0f)
-#define iOS9Later ([UIDevice currentDevice].systemVersion.floatValue >= 9.0f)
+#if (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000)
+
+#define iOS7Later   @available(iOS 7.0, *)
+#define iOS8Later   @available(iOS 8.0, *)
+#define iOS9Later   @available(iOS 9.0, *)
+#define iOS9_1Later @available(iOS 9.1, *)
+#define iOS11Later  @available(iOS 11.0, *)
+
+#else
+
+#define iOS7Later   ([UIDevice currentDevice].systemVersion.floatValue >= 7.0f)
+#define iOS8Later   ([UIDevice currentDevice].systemVersion.floatValue >= 8.0f)
+#define iOS9Later   [UIDevice currentDevice].systemVersion.floatValue >= 9.0f
 #define iOS9_1Later ([UIDevice currentDevice].systemVersion.floatValue >= 9.1f)
-#define iOS11Later ([UIDevice currentDevice].systemVersion.floatValue >= 11.0f)
+#define iOS11Later  ([UIDevice currentDevice].systemVersion.floatValue >= 11.0f)
+
+#endif
 
 @class TZAlbumCell, TZAssetCell;
 @protocol TZImagePickerControllerDelegate;

--- a/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
+++ b/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
@@ -110,9 +110,18 @@
     _isStatusBarDefault = isStatusBarDefault;
     
     if (isStatusBarDefault) {
-        self.statusBarStyle = iOS7Later ? UIStatusBarStyleDefault : UIStatusBarStyleBlackOpaque;
+//        self.statusBarStyle = iOS7Later ? UIStatusBarStyleDefault : UIStatusBarStyleBlackOpaque;
+        if (iOS7Later) {
+            self.statusBarStyle = UIStatusBarStyleDefault;
+        } else {
+            self.statusBarStyle = UIStatusBarStyleBlackOpaque;
+        }
     } else {
-        self.statusBarStyle = iOS7Later ? UIStatusBarStyleLightContent : UIStatusBarStyleBlackOpaque;
+        if (iOS7Later) {
+            self.statusBarStyle = UIStatusBarStyleLightContent;
+        } else {
+            self.statusBarStyle = UIStatusBarStyleBlackOpaque;
+        }
     }
 }
 
@@ -272,7 +281,11 @@
     self.barItemTextColor = [UIColor whiteColor];
     self.allowPreview = YES;
     self.notScaleImage = NO;
-    self.statusBarStyle = UIStatusBarStyleLightContent;
+    if (iOS7Later) {
+        self.statusBarStyle = UIStatusBarStyleLightContent;
+    } else {
+        self.statusBarStyle = UIStatusBarStyleBlackOpaque;
+    }
     self.cannotSelectLayerColor = [[UIColor whiteColor] colorWithAlphaComponent:0.8];
     self.allowCameraLocation = YES;
     
@@ -409,13 +422,21 @@
 }
 
 - (void)hideAlertView:(id)alertView {
-    if ([alertView isKindOfClass:[UIAlertController class]]) {
-        UIAlertController *alertC = alertView;
-        [alertC dismissViewControllerAnimated:YES completion:nil];
-    } else if ([alertView isKindOfClass:[UIAlertView class]]) {
-        UIAlertView *alertV = alertView;
-        [alertV dismissWithClickedButtonIndex:0 animated:YES];
+    if (iOS8Later) {
+        if ([alertView isKindOfClass:[UIAlertController class]]) {
+            UIAlertController *alertC = alertView;
+            [alertC dismissViewControllerAnimated:YES completion:nil];
+        } else if ([alertView isKindOfClass:[UIAlertView class]]) {
+            UIAlertView *alertV = alertView;
+            [alertV dismissWithClickedButtonIndex:0 animated:YES];
+        }
+    } else {
+        if ([alertView isKindOfClass:[UIAlertView class]]) {
+            UIAlertView *alertV = alertView;
+            [alertV dismissWithClickedButtonIndex:0 animated:YES];
+        }
     }
+    
     alertView = nil;
 }
 
@@ -598,7 +619,9 @@
 }
 
 - (void)settingBtnClick {
-    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];
+    if (iOS8Later) {
+        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];
+    }
 }
 
 - (void)pushViewController:(UIViewController *)viewController animated:(BOOL)animated {
@@ -663,7 +686,11 @@
 - (void)willInterfaceOrientionChange {
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.02 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         if (![UIApplication sharedApplication].statusBarHidden) {
-            if (iOS7Later && self.needShowStatusBar) [UIApplication sharedApplication].statusBarHidden = NO;
+            if (self.needShowStatusBar) {
+                if (iOS7Later) {
+                    [UIApplication sharedApplication].statusBarHidden = NO;
+                }
+            }
         }
     });
 }
@@ -792,7 +819,11 @@
     BOOL isStatusBarHidden = [UIApplication sharedApplication].isStatusBarHidden;
     if (self.navigationController.navigationBar.isTranslucent) {
         top = naviBarHeight;
-        if (iOS7Later && !isStatusBarHidden) top += [TZCommonTools tz_statusBarHeight];
+        if (!isStatusBarHidden) {
+            if (iOS7Later) {
+                top += [TZCommonTools tz_statusBarHeight];
+            }
+        }
         tableViewHeight = self.view.tz_height - top;
     } else {
         tableViewHeight = self.view.tz_height;

--- a/TZImagePickerController/TZImagePickerController/TZPhotoPreviewCell.m
+++ b/TZImagePickerController/TZImagePickerController/TZPhotoPreviewCell.m
@@ -190,7 +190,9 @@
 
 - (void)setAsset:(id)asset {
     if (_asset && self.imageRequestID) {
-        [[PHImageManager defaultManager] cancelImageRequest:self.imageRequestID];
+        if (iOS8Later) {
+            [[PHImageManager defaultManager] cancelImageRequest:self.imageRequestID];
+        }
     }
     
     _asset = asset;
@@ -257,12 +259,14 @@
     _allowCrop = allowCrop;
     _scrollView.maximumZoomScale = allowCrop ? 4.0 : 2.5;
     
-    if ([self.asset isKindOfClass:[PHAsset class]]) {
-        PHAsset *phAsset = (PHAsset *)self.asset;
-        CGFloat aspectRatio = phAsset.pixelWidth / (CGFloat)phAsset.pixelHeight;
-        // 优化超宽图片的显示
-        if (aspectRatio > 1.5) {
-            self.scrollView.maximumZoomScale *= aspectRatio / 1.5;
+    if (iOS8Later) {
+        if ([self.asset isKindOfClass:[PHAsset class]]) {
+            PHAsset *phAsset = (PHAsset *)self.asset;
+            CGFloat aspectRatio = phAsset.pixelWidth / (CGFloat)phAsset.pixelHeight;
+            // 优化超宽图片的显示
+            if (aspectRatio > 1.5) {
+                self.scrollView.maximumZoomScale *= aspectRatio / 1.5;
+            }
         }
     }
 }

--- a/TZImagePickerController/TZImagePickerController/TZPhotoPreviewController.m
+++ b/TZImagePickerController/TZImagePickerController/TZPhotoPreviewController.m
@@ -77,8 +77,10 @@
     [super viewWillDisappear:animated];
     [self.navigationController setNavigationBarHidden:NO animated:YES];
     TZImagePickerController *tzImagePickerVc = (TZImagePickerController *)self.navigationController;
-    if (tzImagePickerVc.needShowStatusBar && iOS7Later) {
-        [UIApplication sharedApplication].statusBarHidden = NO;
+    if (tzImagePickerVc.needShowStatusBar) {
+        if (iOS7Later) {
+            [UIApplication sharedApplication].statusBarHidden = NO;
+        }
     }
     [TZImageManager manager].shouldFixOrientation = NO;
 }

--- a/TZImagePickerController/TZImagePickerController/TZVideoPlayerController.m
+++ b/TZImagePickerController/TZImagePickerController/TZVideoPlayerController.m
@@ -49,7 +49,11 @@
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
     _originStatusBarStyle = [UIApplication sharedApplication].statusBarStyle;
-    [UIApplication sharedApplication].statusBarStyle = iOS7Later ? UIStatusBarStyleLightContent : UIStatusBarStyleBlackOpaque;
+    if (iOS7Later) {
+        [UIApplication sharedApplication].statusBarStyle = UIStatusBarStyleLightContent;
+    } else {
+        [UIApplication sharedApplication].statusBarStyle = UIStatusBarStyleBlackOpaque;
+    }
 }
 
 - (void)viewWillDisappear:(BOOL)animated {
@@ -198,8 +202,10 @@
     [self.navigationController setNavigationBarHidden:NO];
     [_playButton setImage:[UIImage imageNamedFromMyBundle:@"MMVideoPreviewPlay"] forState:UIControlStateNormal];
     
-    if (self.needShowStatusBar && iOS7Later) {
-        [UIApplication sharedApplication].statusBarHidden = NO;
+    if (self.needShowStatusBar) {
+        if (iOS7Later) {
+            [UIApplication sharedApplication].statusBarHidden = NO;
+        }
     }
 }
 

--- a/TZImagePickerController/TZTestCell.m
+++ b/TZImagePickerController/TZTestCell.m
@@ -58,14 +58,22 @@
 
 - (void)setAsset:(id)asset {
     _asset = asset;
-    if ([asset isKindOfClass:[PHAsset class]]) {
-        PHAsset *phAsset = asset;
-        _videoImageView.hidden = phAsset.mediaType != PHAssetMediaTypeVideo;
-        _gifLable.hidden = ![[phAsset valueForKey:@"filename"] tz_containsString:@"GIF"];
-    } else if ([asset isKindOfClass:[ALAsset class]]) {
-        ALAsset *alAsset = asset;
-        _videoImageView.hidden = ![[alAsset valueForProperty:ALAssetPropertyType] isEqualToString:ALAssetTypeVideo];
-        _gifLable.hidden = YES;
+    if (iOS8Later) {
+        if ([asset isKindOfClass:[PHAsset class]]) {
+            PHAsset *phAsset = asset;
+            _videoImageView.hidden = phAsset.mediaType != PHAssetMediaTypeVideo;
+            _gifLable.hidden = ![[phAsset valueForKey:@"filename"] tz_containsString:@"GIF"];
+        } else if ([asset isKindOfClass:[ALAsset class]]) {
+            ALAsset *alAsset = asset;
+            _videoImageView.hidden = ![[alAsset valueForProperty:ALAssetPropertyType] isEqualToString:ALAssetTypeVideo];
+            _gifLable.hidden = YES;
+        }
+    } else {
+        if ([asset isKindOfClass:[ALAsset class]]) {
+            ALAsset *alAsset = asset;
+            _videoImageView.hidden = ![[alAsset valueForProperty:ALAssetPropertyType] isEqualToString:ALAssetTypeVideo];
+            _gifLable.hidden = YES;
+        }
     }
  }
 

--- a/TZImagePickerController/ViewController.m
+++ b/TZImagePickerController/ViewController.m
@@ -178,13 +178,21 @@
     } else { // preview photos or video / 预览照片或者视频
         id asset = _selectedAssets[indexPath.item];
         BOOL isVideo = NO;
-        if ([asset isKindOfClass:[PHAsset class]]) {
-            PHAsset *phAsset = asset;
-            isVideo = phAsset.mediaType == PHAssetMediaTypeVideo;
-        } else if ([asset isKindOfClass:[ALAsset class]]) {
-            ALAsset *alAsset = asset;
-            isVideo = [[alAsset valueForProperty:ALAssetPropertyType] isEqualToString:ALAssetTypeVideo];
+        if (iOS8Later) {
+            if ([asset isKindOfClass:[PHAsset class]]) {
+                PHAsset *phAsset = asset;
+                isVideo = phAsset.mediaType == PHAssetMediaTypeVideo;
+            } else if ([asset isKindOfClass:[ALAsset class]]) {
+                ALAsset *alAsset = asset;
+                isVideo = [[alAsset valueForProperty:ALAssetPropertyType] isEqualToString:ALAssetTypeVideo];
+            }
+        } else {
+            if ([asset isKindOfClass:[ALAsset class]]) {
+                ALAsset *alAsset = asset;
+                isVideo = [[alAsset valueForProperty:ALAssetPropertyType] isEqualToString:ALAssetTypeVideo];
+            }
         }
+        
         if ([[asset valueForKey:@"filename"] tz_containsString:@"GIF"] && self.allowPickingGifSwitch.isOn && !self.allowPickingMuitlpleVideoSwitch.isOn) {
             TZGifPhotoPreviewController *vc = [[TZGifPhotoPreviewController alloc] init];
             TZAssetModel *model = [TZAssetModel modelWithAsset:asset type:TZAssetModelMediaTypePhotoGif timeLength:@""];
@@ -331,7 +339,11 @@
     
     // Deprecated, Use statusBarStyle
     // imagePickerVc.isStatusBarDefault = NO;
-    imagePickerVc.statusBarStyle = UIStatusBarStyleLightContent;
+    if (iOS7Later) {
+        imagePickerVc.statusBarStyle = UIStatusBarStyleLightContent;
+    } else {
+        imagePickerVc.statusBarStyle = UIStatusBarStyleBlackOpaque;
+    }
     
     // 设置是否显示图片序号
     imagePickerVc.showSelectedIndex = self.showSelectedIndexSwitch.isOn;
@@ -368,14 +380,16 @@
 
 - (void)takePhoto {
     AVAuthorizationStatus authStatus = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
-    if ((authStatus == AVAuthorizationStatusRestricted || authStatus == AVAuthorizationStatusDenied) && iOS7Later) {
-        // 无相机权限 做一个友好的提示
-        if (iOS8Later) {
-            UIAlertView * alert = [[UIAlertView alloc]initWithTitle:@"无法使用相机" message:@"请在iPhone的""设置-隐私-相机""中允许访问相机" delegate:self cancelButtonTitle:@"取消" otherButtonTitles:@"设置", nil];
-            [alert show];
-        } else {
-            UIAlertView * alert = [[UIAlertView alloc]initWithTitle:@"无法使用相机" message:@"请在iPhone的""设置-隐私-相机""中允许访问相机" delegate:self cancelButtonTitle:@"确定" otherButtonTitles:nil];
-            [alert show];
+    if (authStatus == AVAuthorizationStatusRestricted || authStatus == AVAuthorizationStatusDenied) {
+        if (iOS7Later) {
+            // 无相机权限 做一个友好的提示
+            if (iOS8Later) {
+                UIAlertView * alert = [[UIAlertView alloc]initWithTitle:@"无法使用相机" message:@"请在iPhone的""设置-隐私-相机""中允许访问相机" delegate:self cancelButtonTitle:@"取消" otherButtonTitles:@"设置", nil];
+                [alert show];
+            } else {
+                UIAlertView * alert = [[UIAlertView alloc]initWithTitle:@"无法使用相机" message:@"请在iPhone的""设置-隐私-相机""中允许访问相机" delegate:self cancelButtonTitle:@"确定" otherButtonTitles:nil];
+                [alert show];
+            }
         }
     } else if (authStatus == AVAuthorizationStatusNotDetermined) {
         // fix issue 466, 防止用户首次拍照拒绝授权时相机页黑屏
@@ -511,9 +525,11 @@
     [_selectedPhotos addObject:image];
     [_collectionView reloadData];
     
-    if ([asset isKindOfClass:[PHAsset class]]) {
-        PHAsset *phAsset = asset;
-        NSLog(@"location:%@",phAsset.location);
+    if (iOS8Later) {
+        if ([asset isKindOfClass:[PHAsset class]]) {
+            PHAsset *phAsset = asset;
+            NSLog(@"location:%@",phAsset.location);
+        }
     }
 }
 
@@ -788,12 +804,19 @@
 - (void)printAssetsName:(NSArray *)assets {
     NSString *fileName;
     for (id asset in assets) {
-        if ([asset isKindOfClass:[PHAsset class]]) {
-            PHAsset *phAsset = (PHAsset *)asset;
-            fileName = [phAsset valueForKey:@"filename"];
-        } else if ([asset isKindOfClass:[ALAsset class]]) {
-            ALAsset *alAsset = (ALAsset *)asset;
-            fileName = alAsset.defaultRepresentation.filename;;
+        if (iOS8Later) {
+            if ([asset isKindOfClass:[PHAsset class]]) {
+                PHAsset *phAsset = (PHAsset *)asset;
+                fileName = [phAsset valueForKey:@"filename"];
+            } else if ([asset isKindOfClass:[ALAsset class]]) {
+                ALAsset *alAsset = (ALAsset *)asset;
+                fileName = alAsset.defaultRepresentation.filename;;
+            }
+        } else {
+            if ([asset isKindOfClass:[ALAsset class]]) {
+                ALAsset *alAsset = (ALAsset *)asset;
+                fileName = alAsset.defaultRepresentation.filename;;
+            }
         }
         // NSLog(@"图片名字:%@",fileName);
     }


### PR DESCRIPTION
使用下面代码
#if (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000)
解决做版本判断是没有使用@available()的大量警告

有时候这个库会看到一百多个警告（可能是xcode的bug，有时间编译看不到警告），虽然不影响代码运行，但是大量的警告看着还是很不爽的，而且我们是有办法处理掉的