### PR TITLE
UPDATE 裁剪图片图片能等比自适应填充满裁剪区域

### DIFF
--- a/TZImagePickerController/TZImagePickerController/TZImagePickerController.h
+++ b/TZImagePickerController/TZImagePickerController/TZImagePickerController.h
@@ -159,6 +159,7 @@
 /// 单选模式,maxImagesCount为1时才生效
 @property (nonatomic, assign) BOOL showSelectBtn;        ///< 在单选模式下，照片列表页中，显示选择按钮,默认为NO
 @property (nonatomic, assign) BOOL allowCrop;            ///< 允许裁剪,默认为YES，showSelectBtn为NO才生效
+@property (nonatomic, assign) BOOL scaleAspectFillCrop;  ///< 是否图片等比缩放填充cropRect区域
 @property (nonatomic, assign) CGRect cropRect;           ///< 裁剪框的尺寸
 @property (nonatomic, assign) CGRect cropRectPortrait;   ///< 裁剪框的尺寸(竖屏)
 @property (nonatomic, assign) CGRect cropRectLandscape;  ///< 裁剪框的尺寸(横屏)

--- a/TZImagePickerController/TZImagePickerController/TZPhotoPreviewCell.h
+++ b/TZImagePickerController/TZImagePickerController/TZPhotoPreviewCell.h
@@ -26,6 +26,7 @@
 
 @property (nonatomic, assign) BOOL allowCrop;
 @property (nonatomic, assign) CGRect cropRect;
+@property (nonatomic, assign) BOOL scaleAspectFillCrop;
 
 - (void)recoverSubviews;
 
@@ -40,7 +41,7 @@
 
 @property (nonatomic, assign) BOOL allowCrop;
 @property (nonatomic, assign) CGRect cropRect;
-
+@property (nonatomic, assign) BOOL scaleAspectFillCrop;
 @property (nonatomic, strong) TZAssetModel *model;
 @property (nonatomic, strong) id asset;
 @property (nonatomic, copy) void (^singleTapGestureBlock)(void);

--- a/TZImagePickerController/TZImagePickerController/TZPhotoPreviewController.m
+++ b/TZImagePickerController/TZImagePickerController/TZPhotoPreviewController.m
@@ -464,6 +464,7 @@
         TZPhotoPreviewCell *photoPreviewCell = (TZPhotoPreviewCell *)cell;
         photoPreviewCell.cropRect = _tzImagePickerVc.cropRect;
         photoPreviewCell.allowCrop = _tzImagePickerVc.allowCrop;
+        photoPreviewCell.scaleAspectFillCrop = _tzImagePickerVc.scaleAspectFillCrop;
         __weak typeof(_tzImagePickerVc) weakTzImagePickerVc = _tzImagePickerVc;
         __weak typeof(_collectionView) weakCollectionView = _collectionView;
         __weak typeof(photoPreviewCell) weakCell = photoPreviewCell;


### PR DESCRIPTION
UPDATE 支持裁剪图片时设置TZImagePickerController scaleAspectFillCrop属性为YES时，图片自动按照UIViewContentModeScaleAspectFill模式等比缩放填充cropRect区域

初始不支持等比自动填充的样子
![IMG_0212](https://user-images.githubusercontent.com/12932688/58450216-89205b80-8140-11e9-9f50-71e1d3f99944.PNG)
添加扩展后支持等比填充后的样子
![IMG_0213](https://user-images.githubusercontent.com/12932688/58450242-a7865700-8140-11e9-96ee-2b1f1551b079.PNG)

