### PR TITLE
修复未选中图片情况下，预览图界面点击完成会添加当前图数据作为选中图，但是界面UI不更新的bug

### DIFF
--- a/TZImagePickerController/TZImagePickerController/TZPhotoPreviewController.m
+++ b/TZImagePickerController/TZImagePickerController/TZPhotoPreviewController.m
@@ -383,8 +383,7 @@
     
     // 如果没有选中过照片 点击确定时选中当前预览的照片
     if (_tzImagePickerVc.selectedModels.count == 0 && _tzImagePickerVc.minImagesCount <= 0) {
-        TZAssetModel *model = _models[self.currentIndex];
-        [_tzImagePickerVc addSelectedModel:model];
+        [self select:_selectButton];
     }
     NSIndexPath *indexPath = [NSIndexPath indexPathForItem:self.currentIndex inSection:0];
     TZPhotoPreviewCell *cell = (TZPhotoPreviewCell *)[_collectionView cellForItemAtIndexPath:indexPath];


### PR DESCRIPTION
这是在使用过程中遇到的bug，demo中也复现。  

TZImagePickerController的autoDismiss属性设置为NO，且未选中任何图片的情况下，点击完成，TZImagePickerController会默认选中当前预览的图片，但是如果一旦TZImagePickerController不自动消失，则当前界面的选中UI没有更新（其实是部分更新了），但是选中数据assets中，已有被预览的图片的asset。

后续再选中该图，会导致这张图片被选中两次。  

现在的改动是在点击完成时，且当前界面未选中任何图片，执行一次右上角勾选按钮的响应事件函数，令UI也和数据一并更新。