### PR TITLE
delete sign info of taget:TZImagePickerControllerFramework

### DIFF
--- a/TZImagePickerController.xcodeproj/project.pbxproj
+++ b/TZImagePickerController.xcodeproj/project.pbxproj
@@ -500,7 +500,6 @@
 					};
 					9F763A411FA071CF00D9E526 = {
 						CreatedOnToolsVersion = 9.0.1;
-						DevelopmentTeam = LTFQDC2QVX;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -910,7 +909,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = LTFQDC2QVX;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -951,7 +950,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = LTFQDC2QVX;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";


### PR DESCRIPTION
When I use the shell script to build the framework, it always fails. It was caused by the signature information. Build the framework can without specifying signature information. So I delete it.