### PR TITLE
Fix warning: MobileCoreServices has been renamed. Use CoreServices instead.

### DIFF
--- a/TZImagePickerController.podspec
+++ b/TZImagePickerController.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.resources    = "TZImagePickerController/TZImagePickerController/*.{png,bundle}"
   s.source_files = "TZImagePickerController/TZImagePickerController/*.{h,m}"
-  s.frameworks   = "Photos", "MobileCoreServices"
+  s.frameworks   = "Photos"
 end


### PR DESCRIPTION
Close #1295

If our library was installed via CocoaPods, Xcode 11.4 will issue the warning "MobileCoreServices has been renamed. Use CoreServices instead.".

![image](https://user-images.githubusercontent.com/526008/77892980-eecffd80-72a5-11ea-891b-78acd78d4b7c.png)

How to fix: Do not explicitly link `MobileCoreServices.framework` in the CocoaPods generated project, by deleting `MobileCoreServices` from the `spec.frameworks` attribute in our podspec file.

More info: https://github.com/AFNetworking/AFNetworking/pull/4532
