### PR TITLE
数组进行判空保护,避免崩溃

### DIFF
--- a/TZImagePickerController/TZImagePickerController/TZPhotoPickerController.m
+++ b/TZImagePickerController/TZImagePickerController/TZPhotoPickerController.m
@@ -752,6 +752,9 @@ static CGFloat itemMargin = 5;
     }];
     [photoPreviewVc setDoneButtonClickBlockCropMode:^(UIImage *cropedImage, id asset) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
+        if((!cropedImage)||(!asset)){
+           return;
+        }
         [strongSelf didGetAllPhotos:@[cropedImage] assets:@[asset] infoArr:nil];
     }];
     [self.navigationController pushViewController:photoPreviewVc animated:YES];


### PR DESCRIPTION
线上 bugly 监控到相关崩溃:

类型为:
>-[__NSPlaceholderArray initWithObjects:count:]: attempt to insert nil object from objects[0]

发生路径为:
```
-[TZPhotoPickerController pushPhotoPrevireViewController:needCheckSelectedModels:]_block_invoke.609 (TZPhotoPickerController.m:0)

-[TZPhotoPreviewController doneButtonClick] (TZPhotoPreviewController.m:401)
```
应该是在使用字面量时传了 nil 导致 。