### PR TITLE
圆形裁剪时 设置了cropRect 由于_cropBgView里是一个对称的画圆 而_cropView是设置的圆角边框白线 逻辑不一致 造…

### DIFF
--- a/TZImagePickerController/TZImagePickerController/TZImageCropManager.m
+++ b/TZImagePickerController/TZImagePickerController/TZImageCropManager.m
@@ -19,7 +19,7 @@
     UIBezierPath *path= [UIBezierPath bezierPathWithRect:[UIScreen mainScreen].bounds];
     CAShapeLayer *layer = [CAShapeLayer layer];
     if (needCircleCrop) { // 圆形裁剪框
-        [path appendPath:[UIBezierPath bezierPathWithArcCenter:containerView.center radius:cropRect.size.width / 2 startAngle:0 endAngle: 2 * M_PI clockwise:NO]];
+        [path appendPath:[UIBezierPath bezierPathWithRoundedRect:cropRect cornerRadius:cropRect.size.width / 2]];
     } else { // 矩形裁剪框
         [path appendPath:[UIBezierPath bezierPathWithRect:cropRect]];
     }


### PR DESCRIPTION
…成 镂空圈和白圈位置不同 所以改为画圆角矩形 目前的写法 修正了圆形时 不管rect在哪 都能保持一致 但是如果不是圆形 可能还会有问题 建议把两个的裁切都换成椭圆 更加完美