### PR TITLE
原因是：有潜在Crash的风险。

### DIFF
--- a/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
+++ b/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
@@ -950,7 +950,7 @@
     dispatch_once(&onceToken, ^{
         if (config == nil) {
             config = [[TZImagePickerConfig alloc] init];
-            config.preferredLanguage = nil;
+            config.preferredLanguage = [NSLocale preferredLanguages].firstObject;
             config.gifPreviewMaxImagesCount = 50;
         }
     });
@@ -960,9 +960,7 @@
 - (void)setPreferredLanguage:(NSString *)preferredLanguage {
     _preferredLanguage = preferredLanguage;
     
-    if (!preferredLanguage || !preferredLanguage.length) {
-        preferredLanguage = [NSLocale preferredLanguages].firstObject;
-    }
+#warning 如果你的应用移除了zh-Hant、vi的语言包，移除相应的逻辑 或者 使用下面👇的判断逻辑，以防止Crash
     if ([preferredLanguage rangeOfString:@"zh-Hans"].location != NSNotFound) {
         preferredLanguage = @"zh-Hans";
     } else if ([preferredLanguage rangeOfString:@"zh-Hant"].location != NSNotFound) {
@@ -972,6 +970,13 @@
     } else {
         preferredLanguage = @"en";
     }
+    /* 判空逻辑
+    NSString *languagePath = [[NSBundle tz_imagePickerBundle] pathForResource:preferredLanguage ofType:@"lproj"];
+    NSAssert(languagePath, @"请检查是否缺少了相应的语言文件");
+    if (!languagePath) {
+        preferredLanguage = @"en";
+    }
+    */
     _languageBundle = [NSBundle bundleWithPath:[[NSBundle tz_imagePickerBundle] pathForResource:preferredLanguage ofType:@"lproj"]];
 }
 


### PR DESCRIPTION
具体来说，对于国内应用，为了减少包体积，一般只会留英文和中文文件，假设手机系统偏好语言设置为其他语言，就会Crash，另外，提供了两种选择，移除相应的逻辑或者使用判空逻辑。