### PR TITLE
Use the SPM provided flag

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,10 +23,7 @@ let package = Package(
             name: "TZImagePickerController",
             path: "TZImagePickerController/TZImagePickerController",
             resources: [.process("TZImagePickerController.bundle")],
-            publicHeadersPath: ".",
-            cSettings: [
-                .define("TZ_SPM")
-            ]
+            publicHeadersPath: "."
         )
     ]
 )

--- a/TZImagePickerController/TZImagePickerController/NSBundle+TZImagePicker.m
+++ b/TZImagePickerController/TZImagePickerController/NSBundle+TZImagePicker.m
@@ -12,7 +12,7 @@
 @implementation NSBundle (TZImagePicker)
 
 + (NSBundle *)tz_imagePickerBundle {
-#ifdef TZ_SPM
+#ifdef SWIFT_PACKAGE
     NSBundle *bundle = SWIFTPM_MODULE_BUNDLE;
 #else
     NSBundle *bundle = [NSBundle bundleForClass:[TZImagePickerController class]];


### PR DESCRIPTION
Hi,

This PR changes to use the SPM provided flag instead of a custom definition. See [this document](https://github.com/apple/swift-package-manager/blob/main/Documentation/Usage.md#packaging-legacy-code) for details.