### PR TITLE
fix: 增加loading超时范围

### DIFF
--- a/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
+++ b/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
@@ -524,8 +524,8 @@
     _timeout = timeout;
     if (timeout < 5) {
         _timeout = 5;
-    } else if (_timeout > 60) {
-        _timeout = 60;
+    } else if (_timeout > 600) {
+        _timeout = 600;
     }
 }
 


### PR DESCRIPTION
有些视频比较大, 60秒的导出loading时间根本不够, 故改为超时10分钟