### PR TITLE
fix：选择单张照片时，如果照片的数据为 nil，回传空数组。

### DIFF
--- a/TZImagePickerController/TZImagePickerController/TZPhotoPickerController.m
+++ b/TZImagePickerController/TZImagePickerController/TZPhotoPickerController.m
@@ -825,7 +825,15 @@ static CGFloat itemMargin = 5;
     }];
     [photoPreviewVc setDoneButtonClickBlockCropMode:^(UIImage *cropedImage, id asset) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
-        [strongSelf didGetAllPhotos:@[cropedImage] assets:@[asset] infoArr:nil];
+        NSArray *assets = @[];
+        if (asset) {
+            assets = @[asset];
+        }
+        NSArray *photos = @[];
+        if (cropedImage) {
+            photos = @[cropedImage];
+        }
+        [strongSelf didGetAllPhotos:photos assets:assets infoArr:nil];
     }];
     [self.navigationController pushViewController:photoPreviewVc animated:YES];
 }


### PR DESCRIPTION
- 目前猜测，应该是 asset 为 nil，导致数组插入了 nil 数据闪退
- 业务层使用时判断 photos 和 assets 数组是否为空。避免闪退