### PR TITLE
Fix navigationBar UI.

### DIFF
--- a/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
+++ b/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
@@ -152,6 +152,7 @@
     [super viewWillAppear:animated];
     _originStatusBarStyle = [UIApplication sharedApplication].statusBarStyle;
     [UIApplication sharedApplication].statusBarStyle = self.statusBarStyle;
+    [self configNavigationBarAppearance];
 }
 
 - (void)viewWillDisappear:(BOOL)animated {


### PR DESCRIPTION
由于我这边是引入 **KMNavigationBarTransition** 后，需要在 `viewWillAppear:` 时再次调用 `configNavigationBarAppearance` 以适配 `standardAppearance` 及 `scrollEdgeAppearance`。否则我这边会出现刚进入时导航栏白色的问题，需要触发滑动才可以让导航栏恢复正常。