### PR TITLE
add Symbolic links，调整 Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "TZImagePickerController",
-    platforms: [.iOS(.v8)],
+    platforms: [.iOS(.v9)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
@@ -23,7 +23,10 @@ let package = Package(
             name: "TZImagePickerController",
             path: "TZImagePickerController/TZImagePickerController",
             resources: [.process("TZImagePickerController.bundle")],
-            publicHeadersPath: "."
+            publicHeadersPath: "include",
+            cSettings: [
+                .headerSearchPath(".")
+            ]
         )
     ]
 )

--- a/TZImagePickerController/TZImagePickerController/include/NSBundle+TZImagePicker.h
+++ b/TZImagePickerController/TZImagePickerController/include/NSBundle+TZImagePicker.h
@@ -1,0 +1,1 @@
+../NSBundle+TZImagePicker.h

--- a/TZImagePickerController/TZImagePickerController/include/TZAssetCell.h
+++ b/TZImagePickerController/TZImagePickerController/include/TZAssetCell.h
@@ -1,0 +1,1 @@
+../TZAssetCell.h

--- a/TZImagePickerController/TZImagePickerController/include/TZAssetModel.h
+++ b/TZImagePickerController/TZImagePickerController/include/TZAssetModel.h
@@ -1,0 +1,1 @@
+../TZAssetModel.h

--- a/TZImagePickerController/TZImagePickerController/include/TZAuthLimitedFooterTipView.h
+++ b/TZImagePickerController/TZImagePickerController/include/TZAuthLimitedFooterTipView.h
@@ -1,0 +1,1 @@
+../TZAuthLimitedFooterTipView.h

--- a/TZImagePickerController/TZImagePickerController/include/TZGifPhotoPreviewController.h
+++ b/TZImagePickerController/TZImagePickerController/include/TZGifPhotoPreviewController.h
@@ -1,0 +1,1 @@
+../TZGifPhotoPreviewController.h

--- a/TZImagePickerController/TZImagePickerController/include/TZImageCropManager.h
+++ b/TZImagePickerController/TZImagePickerController/include/TZImageCropManager.h
@@ -1,0 +1,1 @@
+../TZImageCropManager.h

--- a/TZImagePickerController/TZImagePickerController/include/TZImageManager.h
+++ b/TZImagePickerController/TZImagePickerController/include/TZImageManager.h
@@ -1,0 +1,1 @@
+../TZImageManager.h

--- a/TZImagePickerController/TZImagePickerController/include/TZImagePickerController.h
+++ b/TZImagePickerController/TZImagePickerController/include/TZImagePickerController.h
@@ -1,0 +1,1 @@
+../TZImagePickerController.h

--- a/TZImagePickerController/TZImagePickerController/include/TZImageRequestOperation.h
+++ b/TZImagePickerController/TZImagePickerController/include/TZImageRequestOperation.h
@@ -1,0 +1,1 @@
+../TZImageRequestOperation.h

--- a/TZImagePickerController/TZImagePickerController/include/TZPhotoPickerController.h
+++ b/TZImagePickerController/TZImagePickerController/include/TZPhotoPickerController.h
@@ -1,0 +1,1 @@
+../TZPhotoPickerController.h

--- a/TZImagePickerController/TZImagePickerController/include/TZPhotoPreviewCell.h
+++ b/TZImagePickerController/TZImagePickerController/include/TZPhotoPreviewCell.h
@@ -1,0 +1,1 @@
+../TZPhotoPreviewCell.h

--- a/TZImagePickerController/TZImagePickerController/include/TZPhotoPreviewController.h
+++ b/TZImagePickerController/TZImagePickerController/include/TZPhotoPreviewController.h
@@ -1,0 +1,1 @@
+../TZPhotoPreviewController.h

--- a/TZImagePickerController/TZImagePickerController/include/TZProgressView.h
+++ b/TZImagePickerController/TZImagePickerController/include/TZProgressView.h
@@ -1,0 +1,1 @@
+../TZProgressView.h

--- a/TZImagePickerController/TZImagePickerController/include/TZVideoCropController.h
+++ b/TZImagePickerController/TZImagePickerController/include/TZVideoCropController.h
@@ -1,0 +1,1 @@
+../TZVideoCropController.h

--- a/TZImagePickerController/TZImagePickerController/include/TZVideoEditedPreviewController.h
+++ b/TZImagePickerController/TZImagePickerController/include/TZVideoEditedPreviewController.h
@@ -1,0 +1,1 @@
+../TZVideoEditedPreviewController.h

--- a/TZImagePickerController/TZImagePickerController/include/TZVideoPlayerController.h
+++ b/TZImagePickerController/TZImagePickerController/include/TZVideoPlayerController.h
@@ -1,0 +1,1 @@
+../TZVideoPlayerController.h

--- a/TZImagePickerController/TZImagePickerController/include/UIView+TZLayout.h
+++ b/TZImagePickerController/TZImagePickerController/include/UIView+TZLayout.h
@@ -1,0 +1,1 @@
+../UIView+TZLayout.h


### PR DESCRIPTION
头文件通过 Symbolic links 整理在 include 文件夹下，方便 Package.swift 配置 publicHeadersPath