### PR TITLE
Update TZPhotoPreviewController.m

### DIFF
--- a/TZImagePickerController/TZImagePickerController/TZPhotoPreviewController.m
+++ b/TZImagePickerController/TZImagePickerController/TZPhotoPreviewController.m
@@ -79,9 +79,7 @@
     [super viewWillAppear:animated];
     [self.navigationController setNavigationBarHidden:YES animated:YES];
     [UIApplication sharedApplication].statusBarHidden = YES;
-    if (_currentIndex) {
-        [_collectionView setContentOffset:CGPointMake((self.view.tz_width + 20) * self.currentIndex, 0) animated:NO];
-    }
+    [_collectionView setContentOffset:CGPointMake((self.view.tz_width + 20) * self.currentIndex, 0) animated:NO];
     [self refreshNaviBarAndBottomBarState];
 }
 


### PR DESCRIPTION
fix #1623 UIView强制RTL后，点击的照片与详情的照片不一致. 第一张照片图与详情不一致