### PR TITLE
【Fix ios17 crash】UIGraphicsBeginImageContext() failed to allocate CGBitampContext: size={0, 0}, scale=1.000000, bitmapInfo=0x2002. Use UIGraphicsImageRenderer to avoid this assert.

### DIFF
--- a/TZImagePickerController/TZImagePickerController/TZImageManager.m
+++ b/TZImagePickerController/TZImagePickerController/TZImageManager.m
@@ -879,7 +879,7 @@ static dispatch_once_t onceToken;
 
 /// 缩放图片至新尺寸
 - (UIImage *)scaleImage:(UIImage *)image toSize:(CGSize)size {
-    if (image.size.width > size.width,size.width > 0,size.height > 0) {
+    if (image.size.width > size.width && size.width > 0 && size.height > 0) {
         UIGraphicsBeginImageContext(size);
         [image drawInRect:CGRectMake(0, 0, size.width, size.height)];
         UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();

--- a/TZImagePickerController/TZImagePickerController/TZImageManager.m
+++ b/TZImagePickerController/TZImagePickerController/TZImageManager.m
@@ -879,7 +879,7 @@ static dispatch_once_t onceToken;
 
 /// 缩放图片至新尺寸
 - (UIImage *)scaleImage:(UIImage *)image toSize:(CGSize)size {
-    if (image.size.width > size.width) {
+    if (image.size.width > size.width,size.width > 0,size.height > 0) {
         UIGraphicsBeginImageContext(size);
         [image drawInRect:CGRectMake(0, 0, size.width, size.height)];
         UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();


### PR DESCRIPTION
Fix ios17 crash
UIGraphicsBeginImageContext() failed to allocate CGBitampContext: size={0, 0}, scale=1.000000, bitmapInfo=0x2002. Use UIGraphicsImageRenderer to avoid this assert.