### PR TITLE
适配RTL布局

### DIFF
--- a/TZImagePickerController/TZImagePickerController/TZAssetCell.m
+++ b/TZImagePickerController/TZImagePickerController/TZAssetCell.m
@@ -436,10 +436,23 @@
 
 - (void)layoutSubviews {
     [super layoutSubviews];
-    _selectedCountButton.frame = CGRectMake(self.contentView.tz_width - 24, 23, 24, 24);
+    
+    CGFloat selectedCountButtonX;
+    CGFloat titleLabelX;
+    CGFloat posterImageViewX;
+    if ([TZCommonTools tz_isRightToLeftLayout]) {
+        selectedCountButtonX = 24;
+        titleLabelX = 24;
+        posterImageViewX = self.contentView.tz_width - 70;
+    } else {
+        selectedCountButtonX = self.contentView.tz_width - 24;
+        titleLabelX = 80;
+        posterImageViewX = 0;
+    }
+    _selectedCountButton.frame = CGRectMake(selectedCountButtonX, 23, 24, 24);
     NSInteger titleHeight = ceil(self.titleLabel.font.lineHeight);
-    self.titleLabel.frame = CGRectMake(80, (self.tz_height - titleHeight) / 2, self.tz_width - 80 - 50, titleHeight);
-    self.posterImageView.frame = CGRectMake(0, 0, 70, 70);
+    self.titleLabel.frame = CGRectMake(titleLabelX, (self.tz_height - titleHeight) / 2, self.tz_width - 80 - 50, titleHeight);
+    self.posterImageView.frame = CGRectMake(posterImageViewX, 0, 70, 70);
     
     if (self.albumCellDidLayoutSubviewsBlock) {
         self.albumCellDidLayoutSubviewsBlock(self, _posterImageView, _titleLabel);
@@ -472,7 +485,7 @@
         } else {
             titleLabel.textColor = [UIColor blackColor];
         }
-        titleLabel.textAlignment = NSTextAlignmentLeft;
+        titleLabel.textAlignment = NSTextAlignmentNatural;
         [self.contentView addSubview:titleLabel];
         _titleLabel = titleLabel;
     }

--- a/TZImagePickerController/TZImagePickerController/TZGifPhotoPreviewController.m
+++ b/TZImagePickerController/TZImagePickerController/TZGifPhotoPreviewController.m
@@ -19,6 +19,7 @@
 @interface TZGifPhotoPreviewController () {
     UIView *_toolBar;
     UIButton *_doneButton;
+    UILabel *_byteLabel;
     UIProgressView *_progress;
     
     TZPhotoPreviewView *_previewView;
@@ -85,14 +86,14 @@
     }
     [_toolBar addSubview:_doneButton];
     
-    UILabel *byteLabel = [[UILabel alloc] init];
-    byteLabel.textColor = [UIColor whiteColor];
-    byteLabel.font = [UIFont systemFontOfSize:13];
-    byteLabel.frame = CGRectMake(10, 0, 100, 44);
+    _byteLabel = [[UILabel alloc] init];
+    _byteLabel.textColor = [UIColor whiteColor];
+    _byteLabel.font = [UIFont systemFontOfSize:13];
+    __weak typeof(_byteLabel) byteLabel = _byteLabel;
     [[TZImageManager manager] getPhotosBytesWithArray:@[_model] completion:^(NSString *totalBytes) {
         byteLabel.text = totalBytes;
     }];
-    [_toolBar addSubview:byteLabel];
+    [_toolBar addSubview:_byteLabel];
     
     [self.view addSubview:_toolBar];
     
@@ -119,7 +120,14 @@
     CGFloat toolBarHeight = 44 + [TZCommonTools tz_safeAreaInsets].bottom;
     _toolBar.frame = CGRectMake(0, self.view.tz_height - toolBarHeight, self.view.tz_width, toolBarHeight);
     [_doneButton sizeToFit];
-    _doneButton.frame = CGRectMake(self.view.tz_width - _doneButton.tz_width - 12, 0, MAX(44, _doneButton.tz_width), 44);
+    
+    if ([TZCommonTools tz_isRightToLeftLayout]) {
+        _doneButton.frame = CGRectMake(12, 0, MAX(44, _doneButton.tz_width), 44);
+        _byteLabel.frame = CGRectMake(self.view.tz_width - 100 - 10, 0, 100, 44);
+    } else {
+        _doneButton.frame = CGRectMake(self.view.tz_width - _doneButton.tz_width - 12, 0, MAX(44, _doneButton.tz_width), 44);
+        _byteLabel.frame = CGRectMake(10, 0, 100, 44);
+    }
     
     TZImagePickerController *tzImagePickerVc = (TZImagePickerController *)self.navigationController;
     if (tzImagePickerVc.gifPreviewPageDidLayoutSubviewsBlock) {

--- a/TZImagePickerController/TZImagePickerController/TZImagePickerController.h
+++ b/TZImagePickerController/TZImagePickerController/TZImagePickerController.h
@@ -375,6 +375,7 @@
 + (void)configBarButtonItem:(UIBarButtonItem *)item tzImagePickerVc:(TZImagePickerController *)tzImagePickerVc;
 + (BOOL)isICloudSyncError:(NSError *)error;
 + (BOOL)isAssetNotSelectable:(TZAssetModel *)model tzImagePickerVc:(TZImagePickerController *)tzImagePickerVc;
++ (UICollectionViewFlowLayout *)tz_rtlFlowLayout;
 @end
 
 

--- a/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
+++ b/TZImagePickerController/TZImagePickerController/TZImagePickerController.m
@@ -942,6 +942,16 @@
 @end
 
 
+// 适配RTL的UICollectionViewFlowLayout
+@interface TZRTLLayout : UICollectionViewFlowLayout
+@end
+
+@implementation TZRTLLayout
+- (BOOL)flipsHorizontallyInOppositeLayoutDirection {
+    return [TZCommonTools tz_isRightToLeftLayout];
+}
+@end
+
 @implementation TZCommonTools
 
 + (UIEdgeInsets)tz_safeAreaInsets {
@@ -1057,6 +1067,10 @@
         }
     }
     return notSelectable;
+}
+
++ (UICollectionViewFlowLayout *)tz_rtlFlowLayout {
+    return [[TZRTLLayout alloc] init];
 }
 
 @end

--- a/TZImagePickerController/TZImagePickerController/TZPhotoPickerController.m
+++ b/TZImagePickerController/TZImagePickerController/TZPhotoPickerController.m
@@ -175,7 +175,7 @@ static CGFloat itemMargin = 5;
 
 - (void)configCollectionView {
     if (!_collectionView) {
-        _layout = [[UICollectionViewFlowLayout alloc] init];
+        _layout = [TZCommonTools tz_rtlFlowLayout];
         _collectionView = [[TZCollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:_layout];
         if (@available(iOS 13.0, *)) {
             _collectionView.backgroundColor = UIColor.tertiarySystemBackgroundColor;
@@ -290,7 +290,7 @@ static CGFloat itemMargin = 5;
         _originalPhotoButton.enabled = tzImagePickerVc.selectedModels.count > 0;
         
         _originalPhotoLabel = [[UILabel alloc] init];
-        _originalPhotoLabel.textAlignment = NSTextAlignmentLeft;
+        _originalPhotoLabel.textAlignment = NSTextAlignmentNatural;
         _originalPhotoLabel.font = [UIFont systemFontOfSize:16];
         if (@available(iOS 13.0, *)) {
             _originalPhotoLabel.textColor = [UIColor labelColor];
@@ -369,8 +369,11 @@ static CGFloat itemMargin = 5;
     CGFloat collectionViewHeight = 0;
     CGFloat naviBarHeight = self.navigationController.navigationBar.tz_height;
     CGFloat footerTipViewH = _authorizationLimited ? 80 : 0;
+    
     BOOL isStatusBarHidden = [UIApplication sharedApplication].isStatusBarHidden;
     BOOL isFullScreen = self.view.tz_height == [UIScreen mainScreen].bounds.size.height;
+    BOOL isRTL = [TZCommonTools tz_isRightToLeftLayout];
+    
     CGFloat toolBarHeight = 50 + [TZCommonTools tz_safeAreaInsets].bottom;
     if (self.navigationController.navigationBar.isTranslucent) {
         top = naviBarHeight;
@@ -409,16 +412,33 @@ static CGFloat itemMargin = 5;
     if (!tzImagePickerVc.allowPreview) {
         previewWidth = 0.0;
     }
-    _previewButton.frame = CGRectMake(10, 3, previewWidth, 44);
-    _previewButton.tz_width = !tzImagePickerVc.showSelectBtn ? 0 : previewWidth;
+    previewWidth = !tzImagePickerVc.showSelectBtn ? 0 : previewWidth;
+    if (isRTL) {
+        _previewButton.frame = CGRectMake(self.view.tz_width - previewWidth - 10, 3, previewWidth, 44);
+    } else {
+        _previewButton.frame = CGRectMake(10, 3, previewWidth, 44);
+    }
+    
     if (tzImagePickerVc.allowPickingOriginalPhoto) {
         CGFloat fullImageWidth = [tzImagePickerVc.fullImageBtnTitleStr boundingRectWithSize:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX) options:NSStringDrawingUsesFontLeading attributes:@{NSFontAttributeName:[UIFont systemFontOfSize:13]} context:nil].size.width;
-        _originalPhotoButton.frame = CGRectMake(CGRectGetMaxX(_previewButton.frame), 0, fullImageWidth + 56, 50);
-        _originalPhotoLabel.frame = CGRectMake(fullImageWidth + 46, 0, 80, 50);
+        if (isRTL) {
+            _originalPhotoButton.frame = CGRectMake(_previewButton.frame.origin.x - (fullImageWidth + 56), 0, fullImageWidth + 56, 50);
+            _originalPhotoLabel.frame = CGRectMake(-80 + 11, 0, 80, 50);
+        } else {
+            _originalPhotoButton.frame = CGRectMake(CGRectGetMaxX(_previewButton.frame), 0, fullImageWidth + 56, 50);
+            _originalPhotoLabel.frame = CGRectMake(fullImageWidth + 46, 0, 80, 50);
+        }
     }
+    
     [_doneButton sizeToFit];
-    _doneButton.frame = CGRectMake(self.view.tz_width - _doneButton.tz_width - 12, 0, MAX(44, _doneButton.tz_width), 50);
-    _numberImageView.frame = CGRectMake(_doneButton.tz_left - 24 - 5, 13, 24, 24);
+    CGFloat donwButtonWidth = MAX(44, _doneButton.tz_width);
+    if (isRTL) {
+        _doneButton.frame = CGRectMake(12, 0, donwButtonWidth, 50);
+        _numberImageView.frame = CGRectMake(_doneButton.tz_right + 5, 13, 24, 24);
+    } else {
+        _doneButton.frame = CGRectMake(self.view.tz_width - donwButtonWidth - 12, 0, donwButtonWidth, 50);
+        _numberImageView.frame = CGRectMake(_doneButton.tz_left - 24 - 5, 13, 24, 24);
+    }
     _numberLabel.frame = _numberImageView.frame;
     _divideLine.frame = CGRectMake(0, 0, self.view.tz_width, 1);
     

--- a/TZImagePickerController/TZImagePickerController/TZPhotoPreviewController.m
+++ b/TZImagePickerController/TZImagePickerController/TZPhotoPreviewController.m
@@ -149,7 +149,7 @@
         [_originalPhotoButton setImage:_tzImagePickerVc.photoOriginSelImage forState:UIControlStateSelected];
         
         _originalPhotoLabel = [[UILabel alloc] init];
-        _originalPhotoLabel.textAlignment = NSTextAlignmentLeft;
+        _originalPhotoLabel.textAlignment = NSTextAlignmentNatural;
         _originalPhotoLabel.font = [UIFont systemFontOfSize:13];
         _originalPhotoLabel.textColor = [UIColor whiteColor];
         _originalPhotoLabel.backgroundColor = [UIColor clearColor];
@@ -194,7 +194,7 @@
 }
 
 - (void)configCollectionView {
-    _layout = [[UICollectionViewFlowLayout alloc] init];
+    _layout = [TZCommonTools tz_rtlFlowLayout];
     _layout.scrollDirection = UICollectionViewScrollDirectionHorizontal;
     _collectionView = [[UICollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:_layout];
     _collectionView.backgroundColor = [UIColor blackColor];
@@ -260,12 +260,22 @@
     TZImagePickerController *_tzImagePickerVc = (TZImagePickerController *)self.navigationController;
     
     BOOL isFullScreen = self.view.tz_height == [UIScreen mainScreen].bounds.size.height;
+    BOOL isRTL = [TZCommonTools tz_isRightToLeftLayout];
+    
     CGFloat statusBarHeight = isFullScreen ? [TZCommonTools tz_statusBarHeight] : 0;
     CGFloat statusBarHeightInterval = isFullScreen ? (statusBarHeight - 20) : 0;
     CGFloat naviBarHeight = statusBarHeight + _tzImagePickerVc.navigationBar.tz_height;
     _naviBar.frame = CGRectMake(0, 0, self.view.tz_width, naviBarHeight);
-    _backButton.frame = CGRectMake(10, 10 + statusBarHeightInterval, 44, 44);
-    _selectButton.frame = CGRectMake(self.view.tz_width - 56, 10 + statusBarHeightInterval, 44, 44);
+    
+    if (isRTL) {
+        _backButton.frame = CGRectMake(self.view.tz_width - 54, 10 + statusBarHeightInterval, 44, 44);
+        _backButton.layer.transform = CATransform3DMakeRotation(M_PI, 0, 1, 0);
+        _selectButton.frame = CGRectMake(12, 10 + statusBarHeightInterval, 44, 44);
+    } else {
+        _backButton.frame = CGRectMake(10, 10 + statusBarHeightInterval, 44, 44);
+        _selectButton.frame = CGRectMake(self.view.tz_width - 56, 10 + statusBarHeightInterval, 44, 44);
+    }
+    
     _indexLabel.frame = _selectButton.frame;
     
     _layout.itemSize = CGSizeMake(self.view.tz_width + 20, self.view.tz_height);
@@ -286,12 +296,23 @@
     _toolBar.frame = CGRectMake(0, toolBarTop, self.view.tz_width, toolBarHeight);
     if (_tzImagePickerVc.allowPickingOriginalPhoto) {
         CGFloat fullImageWidth = [_tzImagePickerVc.fullImageBtnTitleStr boundingRectWithSize:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX) options:NSStringDrawingUsesFontLeading attributes:@{NSFontAttributeName:[UIFont systemFontOfSize:13]} context:nil].size.width;
-        _originalPhotoButton.frame = CGRectMake(0, 0, fullImageWidth + 56, 44);
-        _originalPhotoLabel.frame = CGRectMake(fullImageWidth + 42, 0, 80, 44);
+        if (isRTL) {
+            _originalPhotoButton.frame = CGRectMake(self.view.tz_width - (fullImageWidth + 56), 0, fullImageWidth + 56, 44);
+            _originalPhotoLabel.frame = CGRectMake(-80 + 15, 0, 80, 44);
+        } else {
+            _originalPhotoButton.frame = CGRectMake(0, 0, fullImageWidth + 56, 44);
+            _originalPhotoLabel.frame = CGRectMake(fullImageWidth + 42, 0, 80, 44);
+        }
     }
+    
     [_doneButton sizeToFit];
-    _doneButton.frame = CGRectMake(self.view.tz_width - _doneButton.tz_width - 12, 0, MAX(44, _doneButton.tz_width), 44);
-    _numberImageView.frame = CGRectMake(_doneButton.tz_left - 24 - 5, 10, 24, 24);
+    if (isRTL) {
+        _doneButton.frame = CGRectMake(12, 0, MAX(44, _doneButton.tz_width), 44);
+        _numberImageView.frame = CGRectMake(_doneButton.tz_right + 5, 10, 24, 24);
+    } else {
+        _doneButton.frame = CGRectMake(self.view.tz_width - _doneButton.tz_width - 12, 0, MAX(44, _doneButton.tz_width), 44);
+        _numberImageView.frame = CGRectMake(_doneButton.tz_left - 24 - 5, 10, 24, 24);
+    }
     _numberLabel.frame = _numberImageView.frame;
     
     [self configCropView];
@@ -651,9 +672,10 @@
     }];
 }
 
-- (NSInteger)currentIndex {
-    return [TZCommonTools tz_isRightToLeftLayout] ? self.models.count - _currentIndex - 1 : _currentIndex;
-}
+// TZRTLLayout已经自动适配，无需手动换算
+//- (NSInteger)currentIndex {
+//    return [TZCommonTools tz_isRightToLeftLayout] ? self.models.count - _currentIndex - 1 : _currentIndex;
+//}
 
 /// 选中/取消选中某张照片
 - (void)setAsset:(PHAsset *)asset isSelect:(BOOL)isSelect {

--- a/TZImagePickerController/TZImagePickerController/TZVideoCropController.m
+++ b/TZImagePickerController/TZImagePickerController/TZVideoCropController.m
@@ -179,10 +179,17 @@
     CGFloat toolBarHeight = 44 + [TZCommonTools tz_safeAreaInsets].bottom;
     CGFloat doneButtonWidth = [_doneButton.currentTitle boundingRectWithSize:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX) options:NSStringDrawingUsesFontLeading attributes:@{NSFontAttributeName:[UIFont systemFontOfSize:16]} context:nil].size.width;
     doneButtonWidth = MAX(44, doneButtonWidth);
-    _cancelButton.frame = CGRectMake(12, self.view.tz_height - toolBarHeight, 44, 44);
+    
     [_cancelButton sizeToFit];
-    _cancelButton.tz_height = 44;
-    _doneButton.frame = CGRectMake(self.view.tz_width - doneButtonWidth - 12, self.view.tz_height - toolBarHeight, doneButtonWidth, 44);
+    
+    if ([TZCommonTools tz_isRightToLeftLayout]) {
+        _doneButton.frame = CGRectMake(12, self.view.tz_height - toolBarHeight, doneButtonWidth, 44);
+        _cancelButton.frame = CGRectMake(self.view.tz_width - _cancelButton.tz_width - 12, self.view.tz_height - toolBarHeight, _cancelButton.tz_width, 44);
+    } else {
+        _doneButton.frame = CGRectMake(self.view.tz_width - doneButtonWidth - 12, self.view.tz_height - toolBarHeight, doneButtonWidth, 44);
+        _cancelButton.frame = CGRectMake(12, self.view.tz_height - toolBarHeight, _cancelButton.tz_width, 44);
+    }
+    
     _playButton.frame = CGRectMake(0, statusBarAndNaviBarHeight, self.view.tz_width, self.view.tz_height - statusBarAndNaviBarHeight - toolBarHeight);
     
     CGFloat collectionViewH = (self.view.tz_width - VideoEditLeftMargin * 2 - 2 * PanImageWidth) / 10.0 * 2;

--- a/TZImagePickerController/TZImagePickerController/TZVideoCropController.m
+++ b/TZImagePickerController/TZImagePickerController/TZVideoCropController.m
@@ -141,10 +141,10 @@
     layout.itemSize = CGSizeMake(_itemW, _itemW * 2);
     layout.minimumLineSpacing = 0;
     layout.minimumInteritemSpacing = 0;
+    layout.sectionInset = UIEdgeInsetsMake(0, VideoEditLeftMargin + PanImageWidth, 0, VideoEditLeftMargin + PanImageWidth);
     _collectionView = [[UICollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:layout];
     _collectionView.dataSource = self;
     _collectionView.delegate = self;
-    _collectionView.contentInset = UIEdgeInsetsMake(0, VideoEditLeftMargin + PanImageWidth, 0, VideoEditLeftMargin + PanImageWidth);
     _collectionView.clipsToBounds = NO;
     _collectionView.showsHorizontalScrollIndicator = NO;
     _collectionView.alwaysBounceHorizontal = YES;
@@ -271,7 +271,12 @@
 
 - (__kindof UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath {
     TZVideoPictureCell *cell = [collectionView dequeueReusableCellWithReuseIdentifier:@"TZVideoPictureCell" forIndexPath:indexPath];
-    cell.imgView.image = self.videoImgArray[indexPath.item];
+    // 在RTL环境下，普通的UICollectionViewFlowLayout的cell是从右到左排列的，所以这里【需要】反向取值
+    if ([TZCommonTools tz_isRightToLeftLayout]) {
+        cell.imgView.image = self.videoImgArray[self.videoImgArray.count - 1 - indexPath.item];
+    } else {
+        cell.imgView.image = self.videoImgArray[indexPath.item];
+    }
     return cell;
 }
 
@@ -279,6 +284,8 @@
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView {
     if (!_isDraging) return;
+    
+    // 在RTL环境下，普通的UICollectionViewFlowLayout的cell虽然是从右到左排列的，但是contentOffset依旧是从左到右的，所以这里【不需要】反向取值
     CGFloat offsetX = scrollView.contentOffset.x;
     if (offsetX - _collectionViewBeginOffsetX >= self.view.tz_width) {
         [self.collectionView setContentOffset:CGPointMake(self.view.tz_width + _collectionViewBeginOffsetX, 0) animated:NO];

--- a/TZImagePickerController/TZImagePickerController/TZVideoEditedPreviewController.m
+++ b/TZImagePickerController/TZImagePickerController/TZVideoEditedPreviewController.m
@@ -88,7 +88,14 @@
     CGFloat toolBarHeight = 44 + [TZCommonTools tz_safeAreaInsets].bottom;
     _toolBar.frame = CGRectMake(0, self.view.tz_height - toolBarHeight, self.view.tz_width, toolBarHeight);
     [_doneButton sizeToFit];
-    _doneButton.frame = CGRectMake(self.view.tz_width - _doneButton.tz_width - 12, 0, MAX(44, _doneButton.tz_width), 44);
+    
+    CGFloat doneButtonWidth = MAX(44, _doneButton.tz_width);
+    if ([TZCommonTools tz_isRightToLeftLayout]) {
+        _doneButton.frame = CGRectMake(12, 0, doneButtonWidth, 44);
+    } else {
+        _doneButton.frame = CGRectMake(self.view.tz_width - doneButtonWidth - 12, 0, doneButtonWidth, 44);
+    }
+    
     _playButton.frame = CGRectMake(0, statusBarAndNaviBarHeight, self.view.tz_width, self.view.tz_height - statusBarAndNaviBarHeight - toolBarHeight);
     _playerLayer.frame = self.view.bounds;
 }

--- a/TZImagePickerController/TZImagePickerController/TZVideoPlayerController.m
+++ b/TZImagePickerController/TZImagePickerController/TZVideoPlayerController.m
@@ -170,18 +170,27 @@
     TZImagePickerController *tzImagePickerVc = (TZImagePickerController *)self.navigationController;
     
     BOOL isFullScreen = self.view.tz_height == [UIScreen mainScreen].bounds.size.height;
+    BOOL isRTL = [TZCommonTools tz_isRightToLeftLayout];
+    
     CGFloat statusBarHeight = isFullScreen ? [TZCommonTools tz_statusBarHeight] : 0;
     CGFloat statusBarAndNaviBarHeight = statusBarHeight + self.navigationController.navigationBar.tz_height;
     _playerLayer.frame = self.view.bounds;
     CGFloat toolBarHeight = 44 + [TZCommonTools tz_safeAreaInsets].bottom;
     _toolBar.frame = CGRectMake(0, self.view.tz_height - toolBarHeight, self.view.tz_width, toolBarHeight);
     [_doneButton sizeToFit];
-    _doneButton.frame = CGRectMake(self.view.tz_width - _doneButton.tz_width - 12, 0, MAX(44, _doneButton.tz_width), 44);
+    if (isRTL) {
+        _doneButton.frame = CGRectMake(12, 0, MAX(44, _doneButton.tz_width), 44);
+    } else {
+        _doneButton.frame = CGRectMake(self.view.tz_width - _doneButton.tz_width - 12, 0, MAX(44, _doneButton.tz_width), 44);
+    }
     _playButton.frame = CGRectMake(0, statusBarAndNaviBarHeight, self.view.tz_width, self.view.tz_height - statusBarAndNaviBarHeight - toolBarHeight);
     if (tzImagePickerVc.allowEditVideo) {
-        _editButton.frame = CGRectMake(12, 0, 44, 44);
         [_editButton sizeToFit];
-        _editButton.tz_height = 44;
+        if (isRTL) {
+            _editButton.frame = CGRectMake(self.view.tz_width - _editButton.tz_width - 12, 0, _editButton.tz_width, 44);
+        } else {
+            _editButton.frame = CGRectMake(12, 0, _editButton.tz_width, 44);
+        }
     }
     if (tzImagePickerVc.videoPreviewPageDidLayoutSubviewsBlock) {
         tzImagePickerVc.videoPreviewPageDidLayoutSubviewsBlock(_playButton, _toolBar, _editButton, _doneButton);


### PR DESCRIPTION
你好，关于TZImagePickerController的部分UI并没有做RTL布局的适配，我为此做出了以下补全：

1.TZPhotoPickerController
![111](https://github.com/user-attachments/assets/081cac60-32b0-438b-9be1-6948a66b9a32)
![777](https://github.com/user-attachments/assets/70ad0dd3-dcdc-49c7-a9fa-827caa556136)

2.TZPhotoPreviewController
![222](https://github.com/user-attachments/assets/d28a69f6-0b6f-4772-b570-ab634cf31661)

3.TZVideoPlayerController
![333](https://github.com/user-attachments/assets/99dced81-9df6-4e52-b756-eab66d4dc47f)

4.TZVideoCropController
![444](https://github.com/user-attachments/assets/3ec247f1-aba9-421c-8a1a-9585475fdd4c)

5.TZVideoEditedPreviewController
![555](https://github.com/user-attachments/assets/559d1583-b245-4071-8cd7-ec556be4f11f)

6.TZGifPhotoPreviewController
![666](https://github.com/user-attachments/assets/8820991b-9ed9-4d0f-b125-04c065d65ea0)

主要是导航栏和底部工具栏的镜像布局。

另外需要说明的是，UICollectionView的RTL布局在水平方向是从右到左排序的，并且使用普通的UICollectionViewFlowLayout的话，cell虽然是从右到左排列的，但是contentOffset依旧是从左到右的。为此TZPhotoPickerController和TZPhotoPreviewController部分我都处理好了，但是TZVideoCropController的视频裁剪区我并没有做RTL适配，主要是因为你的裁剪框已经固定了从左边开始算起，我只好在RTL环境下让视频裁剪区还是固定LTR布局了😅。

如果你觉得没问题的话，可以合并一下😁。