### PR TITLE
当 (insertedCount == 0 && removedCount == 0 && changedCount > 1) 时，直接退…

### DIFF
--- a/TZImagePickerController/TZImagePickerController/TZPhotoPickerController.m
+++ b/TZImagePickerController/TZImagePickerController/TZPhotoPickerController.m
@@ -1144,7 +1144,7 @@ static CGFloat itemMargin = 5;
             NSInteger insertedCount = changeDetail.insertedObjects.count;
             NSInteger removedCount = changeDetail.removedObjects.count;
             NSInteger changedCount = changeDetail.changedObjects.count;
-            if (insertedCount == 0 && removedCount == 0 && changedCount > 1) {
+            if (insertedCount == 0 && removedCount == 0 && changedCount > 0) {
                 return;
             } else if (insertedCount > 0 || removedCount > 0 || changedCount > 0) {
                 self.model.result = changeDetail.fetchResultAfterChanges;

--- a/TZImagePickerController/TZImagePickerController/TZPhotoPickerController.m
+++ b/TZImagePickerController/TZImagePickerController/TZPhotoPickerController.m
@@ -1144,8 +1144,14 @@ static CGFloat itemMargin = 5;
             NSInteger insertedCount = changeDetail.insertedObjects.count;
             NSInteger removedCount = changeDetail.removedObjects.count;
             NSInteger changedCount = changeDetail.changedObjects.count;
-            if (insertedCount == 0 && removedCount == 0 && changedCount > 0) {
-                return;
+            
+            // 只 changed：精准更新
+            if (insertedCount == 0 && removedCount == 0 && changedCount > 0 && !changeDetail.hasMoves) {
+                NSArray *changedAssets = [[changeDetail changedObjects] copy];
+                self.model.result = changeDetail.fetchResultAfterChanges;
+                self.model.count = changeDetail.fetchResultAfterChanges.count;
+                // 使用 updateAssetModels 方法更新特定资产
+                [self updateAssetModels:changedAssets];
             } else if (insertedCount > 0 || removedCount > 0 || changedCount > 0) {
                 self.model.result = changeDetail.fetchResultAfterChanges;
                 self.model.count = changeDetail.fetchResultAfterChanges.count;
@@ -1168,6 +1174,58 @@ static CGFloat itemMargin = 5;
         }
         [self refreshBottomToolBarStatus];
     }
+}
+
+#pragma mark - Update Asset Models
+
+// 更新特定的asset models
+- (void)updateAssetModels:(NSArray<PHAsset *> *)changedAssets {
+    
+    TZImagePickerController *tzImagePickerVc = (TZImagePickerController *)self.navigationController;  
+    dispatch_async(dispatch_get_global_queue(0, 0), ^{
+                
+        CGFloat systemVersion = [[[UIDevice currentDevice] systemVersion] floatValue];
+        if (!tzImagePickerVc.sortAscendingByModificationDate && self->_model.isCameraRoll) {
+            [[TZImageManager manager] getCameraRollAlbumWithFetchAssets:YES completion:^(TZAlbumModel *model) {
+                self->_model = model;
+                self->_models = [NSMutableArray arrayWithArray:self->_model.models];
+            }];
+        } else if (self->_showTakePhotoBtn || !self.model.models || systemVersion >= 14.0) {
+            [[TZImageManager manager] getAssetsFromFetchResult:self->_model.result completion:^(NSArray<TZAssetModel *> *models) {
+                self->_models = [NSMutableArray arrayWithArray:models];
+            }];
+        } else {
+            self->_models = [NSMutableArray arrayWithArray:self->_model.models];
+        }
+        
+        // 通过对比 localIdentifier 来找到索引
+        NSMutableArray<NSNumber *> *updatedIndexes = [NSMutableArray array];
+        for (PHAsset *asset in changedAssets) {
+            for (int i = 0; i < self.model.count; i++) {
+                TZAssetModel *currentModel = self->_models[i];
+                if ([currentModel.asset.localIdentifier isEqualToString:asset.localIdentifier]) {
+                    [updatedIndexes addObject:@(i)];
+                    break;
+                }
+            }
+        }
+        
+        if (updatedIndexes.count > 0) {
+            NSMutableArray<NSIndexPath *> *indexPaths = [NSMutableArray array];
+            for (NSNumber *indexNum in updatedIndexes) {
+                NSIndexPath *indexPath = [NSIndexPath indexPathForItem:[indexNum intValue] inSection:0];
+                [indexPaths addObject:indexPath];
+            }
+
+            // 重载指定的items
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self.collectionView reloadItemsAtIndexPaths:indexPaths];
+            });
+        } else {
+            NSLog(@"updateAssetModels no changes, models.count:%ld", (long)self.model.count);
+        }
+        
+    });
 }
 
 #pragma mark - Asset Caching

--- a/TZImagePickerController/TZImagePickerController/TZPhotoPickerController.m
+++ b/TZImagePickerController/TZImagePickerController/TZPhotoPickerController.m
@@ -1144,7 +1144,9 @@ static CGFloat itemMargin = 5;
             NSInteger insertedCount = changeDetail.insertedObjects.count;
             NSInteger removedCount = changeDetail.removedObjects.count;
             NSInteger changedCount = changeDetail.changedObjects.count;
-            if (insertedCount > 0 || removedCount > 0 || changedCount > 0) {
+            if (insertedCount == 0 && removedCount == 0 && changedCount > 1) {
+                return;
+            } else if (insertedCount > 0 || removedCount > 0 || changedCount > 0) {
                 self.model.result = changeDetail.fetchResultAfterChanges;
                 self.model.count = changeDetail.fetchResultAfterChanges.count;
                 [self fetchAssetModels];


### PR DESCRIPTION
### 问题

在受限访问模式下， 使用系统的拍照界面拍一张， 回到app中，会出现闪烁

如下方视频中的 8s出现的闪烁


https://github.com/user-attachments/assets/343657a5-a9dc-4a08-bc9f-8560b1b25508


### 原因：
1. 使用系统拍照后,回到app （未添加新拍的相片），触发photoLibraryDidChange 函数回调
2. 此时 changeDetail.insertedObjects.count = 0 ， changeDetail.removedObjects.count = 0 ， changeDetail.changedObjects.count > 1   导致无谓的fetchAssetModels 刷新导致

### 修改

当 (insertedCount == 0 && removedCount == 0 && changedCount > 0) 时，直接退出return 。不进行刷新